### PR TITLE
Fix multiple children snapshot

### DIFF
--- a/lib/active_snapshot/models/concerns/snapshots_concern.rb
+++ b/lib/active_snapshot/models/concerns/snapshots_concern.rb
@@ -101,9 +101,9 @@ module ActiveSnapshot
           else
             raise ArgumentError.new("Invalid `has_snapshot_children` definition. Invalid :records argument. Must be a Hash or Array")
           end
-
-          return snapshot_children
         end
+
+        return snapshot_children
       end
     end
 

--- a/test/dummy_app/app/models/note.rb
+++ b/test/dummy_app/app/models/note.rb
@@ -1,0 +1,5 @@
+class Note < ActiveRecord::Base
+  include ActiveSnapshot
+
+  belongs_to :post
+end

--- a/test/dummy_app/app/models/post.rb
+++ b/test/dummy_app/app/models/post.rb
@@ -2,12 +2,14 @@ class Post < ActiveRecord::Base
   include ActiveSnapshot
 
   has_many :comments
+  has_many :notes
 
   has_snapshot_children do
-    instance = self.class.includes(:comments).find(id)
+    instance = self.class.includes(:comments, :notes).find(id)
 
     {
       comments: instance.comments,
+      notes: instance.notes,
     }
   end
 end

--- a/test/dummy_app/db/migrate/20210128155312_set_up_test_tables.rb
+++ b/test/dummy_app/db/migrate/20210128155312_set_up_test_tables.rb
@@ -14,6 +14,14 @@ class SetUpTestTables < ActiveRecord::Migration::Current
 
       t.timestamps
     end
+
+    create_table :notes do |t|
+      t.string :body
+
+      t.references :post
+
+      t.timestamps
+    end
   end
 
 end

--- a/test/models/snapshots_concern_test.rb
+++ b/test/models/snapshots_concern_test.rb
@@ -106,6 +106,12 @@ class SnapshotsConcernTest < ActiveSupport::TestCase
 
       klass.new.children_to_snapshot
     end
+
+    klass.has_snapshot_children do
+      {foo: {records: 'bar'}, baz: {records: 'barbaz'}}
+    end
+
+    assert klass.new.children_to_snapshot.count == 2
   end
 
 end


### PR DESCRIPTION
There is wrong working with multiple model's children.
In the case when we defined:
```ruby
has_snapshot_children do
  instance = self.class.includes(:comments, :notes).find(id)

  {
    comments: instance.comments,
    notes: instance.notes
  }
end
```
The result will be contained only first instance relation - `comments`.