### PR TITLE
Set implicit empty snapshot children

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ has_many :snapshots, as: :item, class_name: 'Snapshot'
 has_many :snapshot_items, as: :item, class_name: 'SnapshotItem'
 ```
 
-It defines an optional extension to your model `has_snapshot_children`.
+It defines an optional extension to your model: `has_snapshot_children`.
 
 It defines one instance method to your model: `create_snapshot!`
 

--- a/lib/active_snapshot/models/concerns/snapshots_concern.rb
+++ b/lib/active_snapshot/models/concerns/snapshots_concern.rb
@@ -53,7 +53,7 @@ module ActiveSnapshot
       snapshot_children_proc = self.class.has_snapshot_children
 
       if !snapshot_children_proc
-        raise ArgumentError.new("`has_snapshot_children` must be defined on your class")
+        return {}
       else
         records = self.instance_exec(&snapshot_children_proc)
 


### PR DESCRIPTION
Resolves https://github.com/westonganger/active_snapshot/issues/4

Now calling `has_snapshot_children` is optional as the documentation states and it will be set as an empty hash by default. Calling it will override the default. 

After this change, the following condition will return always `false`, but I think it's okay to keep it just in case this default is removed in the future: https://github.com/westonganger/active_snapshot/blob/23a769fbe1f42adecbb81edf015a0c5fc518767d/lib/active_snapshot/models/concerns/snapshots_concern.rb#L41-L42