### PR TITLE
fix: Sub classes of a model would not be assigned correctly as parent when reifying

### DIFF
--- a/lib/active_snapshot/models/snapshot.rb
+++ b/lib/active_snapshot/models/snapshot.rb
@@ -98,7 +98,7 @@ module ActiveSnapshot
 
           reified_children_hash[key] << reified_item
 
-        elsif [self.item_id, self.item_type] == [si.item_id, si.item_type]
+        elsif self.item_id == si.item_id && si.item_type.constantize.new.is_a?(self.item_type.constantize)
           reified_parent = reified_item
         end
       end

--- a/lib/active_snapshot/models/snapshot.rb
+++ b/lib/active_snapshot/models/snapshot.rb
@@ -98,7 +98,7 @@ module ActiveSnapshot
 
           reified_children_hash[key] << reified_item
 
-        elsif self.item_id == si.item_id && si.item_type.constantize.new.is_a?(self.item_type.constantize)
+        elsif self.item_id == si.item_id && (self.item_type == si.item_type || si.item_type.constantize.new.is_a?(self.item_type.constantize))
           reified_parent = reified_item
         end
       end

--- a/test/dummy_app/app/models/sub_post.rb
+++ b/test/dummy_app/app/models/sub_post.rb
@@ -1,0 +1,11 @@
+class SubPost < Post
+  has_snapshot_children do
+    instance = self.class.includes(:comments, :notes).find(id)
+
+    {
+      comments: instance.comments,
+      notes: instance.notes,
+      nil_assoc: nil,
+    }
+  end
+end

--- a/test/models/snapshot_test.rb
+++ b/test/models/snapshot_test.rb
@@ -106,4 +106,16 @@ class SnapshotTest < ActiveSupport::TestCase
     assert children_hash.all?{|k,v| v.all?{|x| x.readonly?} }
   end
 
+  def test_fetch_reified_items_with_sti_class
+    post = SubPost.create!(a: 1, b: 2)
+    comment_content = 'Example comment'
+    post.comments.create!(content: comment_content)
+    post.create_snapshot!('v1')
+    snapshot = post.snapshots.first
+    reified_items = snapshot.fetch_reified_items
+
+    assert_equal post, reified_items.first
+    assert reified_items.first.readonly?
+    assert_equal comment_content, reified_items.second[:comments].first.content
+  end
 end


### PR DESCRIPTION
Parent currently compared on exact type. This PR ensures the parent matches on a subclass aka `is_a?`.

Covered with a simple test.

It looks like the data isn't wiped after each test so if you'd prefer I move the creation of `SubPost` to the `test_helper`, let me know.