### PR TITLE
Resolve error when `has_snapshot_children` has not been defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 - **UNRELEASED**
   * [View Diff](https://github.com/westonganger/active_snapshot/compare/v0.2.3...master)
+  * [PR #20](https://github.com/westonganger/active_snapshot/pull/20) - Resolve error when `has_snapshot_children` has not been defined as it should be optional
   * [PR #18](https://github.com/westonganger/active_snapshot/pull/18) - Fix bug where sub-classes of a model would not be assigned correctly as parent when restoring
 
 - **v0.2.3** - Jan 7, 2022

--- a/lib/active_snapshot/models/concerns/snapshots_concern.rb
+++ b/lib/active_snapshot/models/concerns/snapshots_concern.rb
@@ -38,9 +38,7 @@ module ActiveSnapshot
     class_methods do
 
       def has_snapshot_children(&block)
-        if !block_given? && !defined?(@snapshot_children_proc)
-          raise ArgumentError.new("Invalid `has_snapshot_children` requires block to be defined")
-        elsif block_given?
+        if block_given?
           @snapshot_children_proc = block
         else
           @snapshot_children_proc

--- a/test/dummy_app/app/models/parent_without_children.rb
+++ b/test/dummy_app/app/models/parent_without_children.rb
@@ -1,0 +1,5 @@
+class ParentWithoutChildren < ApplicationRecord
+  include ActiveSnapshot
+
+  self.table_name = "posts"
+end

--- a/test/models/snapshot_test.rb
+++ b/test/models/snapshot_test.rb
@@ -118,4 +118,23 @@ class SnapshotTest < ActiveSupport::TestCase
     assert reified_items.first.readonly?
     assert_equal comment_content, reified_items.second[:comments].first.content
   end
+
+  def test_single_model_snapshots_without_children
+    instance = ParentWithoutChildren.create!({a: 1, b: 2})
+
+    previous_attributes = instance.attributes
+
+    instance.create_snapshot!('v1')
+
+    instance.update!(a: 9, b: 9)
+
+    snapshot = instance.snapshots.first
+
+    reified_items = snapshot.fetch_reified_items
+
+    assert_equal [instance, {}], reified_items
+
+    assert_equal previous_attributes, reified_items.first.attributes
+  end
+
 end

--- a/test/models/snapshots_concern_test.rb
+++ b/test/models/snapshots_concern_test.rb
@@ -52,9 +52,7 @@ class SnapshotsConcernTest < ActiveSupport::TestCase
   def test_has_snapshot_children
     klass = VolatilePost
     
-    assert_raise ArgumentError do
-      klass.has_snapshot_children
-    end
+    assert_nil klass.has_snapshot_children
 
     klass.has_snapshot_children do
       {}


### PR DESCRIPTION
Solves #4 

Replaces the work started in #19 

