### PR TITLE
Use correct create_table syntax

### DIFF
--- a/lib/generators/active_snapshot/migration_generator.rb
+++ b/lib/generators/active_snapshot/migration_generator.rb
@@ -66,7 +66,7 @@ module ActiveSnapshot
     #
     def table_options
       if mysql?
-        ', { options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" }'
+        ', options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"'
       else
         ""
       end


### PR DESCRIPTION
Removed the brackets to make the argument passed to `create_table` in the migration generator a single hash as the method expects.
https://apidock.com/rails/v6.1.3.1/ActiveRecord/ConnectionAdapters/SchemaStatements/create_table