### PR TITLE
#15 Using JSON Column instead of YAML encoded object column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 - **UNRELEASED**
   * [View Diff](https://github.com/westonganger/active_snapshot/compare/v0.2.4...master)
   * [PR #24](https://github.com/westonganger/active_snapshot/pull/24) - Fix arguments for db migration for mysql
+  * [PR #25](https://github.com/westonganger/active_snapshot/pull/25) - Option to use JSON column instead of YAML encoded objects
 - **v0.2.4** - Feb 25, 2022
   * [View Diff](https://github.com/westonganger/active_snapshot/compare/v0.2.3...v0.2.4)
   * [PR #20](https://github.com/westonganger/active_snapshot/pull/20) - Resolve error when `has_snapshot_children` has not been defined as it should be optional

--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ It defines an optional extension to your model: `has_snapshot_children`.
 
 It defines one instance method to your model: `create_snapshot!`
 
+# Using JSON columns too store encoded object
+
+ActiveSnapshot by default encodes objects to YAML and stores them id database as plain text. If you prefer to use JSON columns (such as PostgreSQL JSONB) add an initializer with following configuration:
+
+```ruby
+ActiveSnapshot::Config.setup do
+  self.storage_method = :json
+end
+```
+
+and in generated migration change `snapshots.metadata` and `snapshot_items.object` column types to `jsonb`.
+
 # Basic Usage
 
 You now have access to the following methods:

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ It defines an optional extension to your model: `has_snapshot_children`.
 
 It defines one instance method to your model: `create_snapshot!`
 
-# Using JSON columns too store encoded object
+# Using JSON columns to store encoded object
 
-ActiveSnapshot by default encodes objects to YAML and stores them id database as plain text. If you prefer to use JSON columns (such as PostgreSQL JSONB) add an initializer with following configuration:
+By default ActiveSnapshot encodes objects to YAML and stores them in database as plain text. If you prefer to use JSON columns (or similar such as JSONB) add an initializer with following configuration:
 
 ```ruby
 ActiveSnapshot::Config.setup do

--- a/lib/active_snapshot.rb
+++ b/lib/active_snapshot.rb
@@ -2,6 +2,7 @@ require "active_record"
 require "activerecord-import"
 
 require "active_snapshot/version"
+require "active_snapshot/config"
 
 require "active_snapshot/models/snapshot"
 require "active_snapshot/models/snapshot_item"

--- a/lib/active_snapshot/config.rb
+++ b/lib/active_snapshot/config.rb
@@ -1,11 +1,17 @@
 class ActiveSnapshot::Config
   class << self
-    attr_accessor :storage_method
+    attr_reader :storage_method
   end
 
   def self.setup(&block)
-    @storage_method = :yaml
+    self.storage_method = :yaml
     instance_eval(&block) if block_given?
+  end
+
+  def self.storage_method=(value)
+    if [:yaml, :json].include?(value)
+      @storage_method = value
+    end
   end
 
   def self.storage_method_yaml?

--- a/lib/active_snapshot/config.rb
+++ b/lib/active_snapshot/config.rb
@@ -1,25 +1,28 @@
+# frozen_string_literal: true
+
 class ActiveSnapshot::Config
   class << self
     attr_reader :storage_method
   end
 
   def self.setup(&block)
-    self.storage_method = :yaml
+    self.storage_method = 'yaml'
     instance_eval(&block) if block_given?
   end
 
   def self.storage_method=(value)
-    if [:yaml, :json].include?(value)
-      @storage_method = value
+    value_str = value.to_s
+    if ['yaml', 'json'].include?(value_str)
+      @storage_method = value_str
     end
   end
 
   def self.storage_method_yaml?
-    @storage_method == :yaml
+    @storage_method == 'yaml'
   end
 
   def self.storage_method_json?
-    @storage_method == :json
+    @storage_method == 'json'
   end
 end
 

--- a/lib/active_snapshot/config.rb
+++ b/lib/active_snapshot/config.rb
@@ -1,0 +1,20 @@
+class ActiveSnapshot::Config
+  class << self
+    attr_accessor :storage_method
+  end
+
+  def self.setup(&block)
+    @storage_method = :yaml
+    instance_eval(&block) if block_given?
+  end
+
+  def self.storage_method_yaml?
+    @storage_method == :yaml
+  end
+
+  def self.storage_method_json?
+    @storage_method == :json
+  end
+end
+
+ActiveSnapshot::Config.setup

--- a/lib/active_snapshot/models/snapshot_item.rb
+++ b/lib/active_snapshot/models/snapshot_item.rb
@@ -14,23 +14,32 @@ module ActiveSnapshot
     validates :item_type, presence: true, uniqueness: { scope: [:snapshot_id, :item_id] }
 
     def object
-      yaml_method = "unsafe_load"
+      if ActiveSnapshot::Config.storage_method_yaml?
+        yaml_method = "unsafe_load"
 
-      if !YAML.respond_to?("unsafe_load")
-        yaml_method = "load"
+        if !YAML.respond_to?("unsafe_load")
+          yaml_method = "load"
+        end
+
+        @object ||= YAML.send(yaml_method, self[:object]).with_indifferent_access
+      elsif ActiveSnapshot::Config.storage_method_json?
+        @object ||= self[:object].with_indifferent_access
       end
-
-      @metadata ||= YAML.send(yaml_method, self[:object]).with_indifferent_access
     end
 
     def object=(h)
       @object = nil
-      self[:object] = YAML.dump(h)
+
+      if ActiveSnapshot::Config.storage_method_yaml?
+        self[:object] = YAML.dump(h)
+      elsif ActiveSnapshot::Config.storage_method_json?
+        self[:object] = JSON.parse(h.to_json)
+      end
     end
 
     def restore_item!
       ### Add any custom logic here
-      
+
       if !item
         item_klass = item_type.constantize
 

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -7,6 +7,10 @@ class ConfigTest < ActiveSupport::TestCase
         ActiveSnapshot::Config.setup
     end
 
+    def teardown
+        ActiveSnapshot::Config.storage_method = @configured_storage_method
+    end
+
     def test_defaults_to_yaml
         assert_equal ActiveSnapshot::Config.storage_method, 'yaml'
         assert_equal ActiveSnapshot::Config.storage_method_yaml?, true
@@ -53,10 +57,6 @@ class ConfigTest < ActiveSupport::TestCase
         
         assert_equal ActiveSnapshot::Config.storage_method, 'yaml'
         assert_equal ActiveSnapshot::Config.storage_method_yaml?, true
-    end
-
-    def teardown
-        ActiveSnapshot::Config.storage_method = @configured_storage_method
     end
 
     private

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class ConfigTest < ActiveSupport::TestCase
+    
+    def setup
+        @configured_storage_method = ActiveSnapshot::Config.storage_method
+        ActiveSnapshot::Config.setup
+    end
+
+    def test_defaults_to_yaml
+        assert_equal ActiveSnapshot::Config.storage_method, 'yaml'
+        assert_equal ActiveSnapshot::Config.storage_method_yaml?, true
+        assert_equal ActiveSnapshot::Config.storage_method_json?, false
+    end
+
+    def test_accepts_json_config_via_string
+        ActiveSnapshot::Config.storage_method = 'json'
+
+        assert_equal ActiveSnapshot::Config.storage_method, 'json'
+        assert_equal ActiveSnapshot::Config.storage_method_json?, true
+        assert_equal ActiveSnapshot::Config.storage_method_yaml?, false
+    end
+    
+    def test_accepts_json_config_via_symbol
+        ActiveSnapshot::Config.storage_method = :json
+
+        assert_equal ActiveSnapshot::Config.storage_method, 'json'
+        assert_equal ActiveSnapshot::Config.storage_method_json?, true
+        assert_equal ActiveSnapshot::Config.storage_method_yaml?, false
+    end
+
+    def test_accepts_yaml_config_via_string
+        switch_storage_method_to_json
+        ActiveSnapshot::Config.storage_method = 'yaml'
+
+        assert_equal ActiveSnapshot::Config.storage_method, 'yaml'
+        assert_equal ActiveSnapshot::Config.storage_method_yaml?, true
+        assert_equal ActiveSnapshot::Config.storage_method_json?, false
+    end
+
+    def test_accepts_yaml_config_via_symbol
+        switch_storage_method_to_json
+        ActiveSnapshot::Config.storage_method = :yaml
+
+        assert_equal ActiveSnapshot::Config.storage_method, 'yaml'
+        assert_equal ActiveSnapshot::Config.storage_method_yaml?, true
+        assert_equal ActiveSnapshot::Config.storage_method_json?, false
+    end
+
+    def test_config_doesnt_accept_not_specified_storage_methods
+        ActiveSnapshot::Config.storage_method = 'anything'
+        ActiveSnapshot::Config.storage_method = 'jsoon'
+        
+        assert_equal ActiveSnapshot::Config.storage_method, 'yaml'
+        assert_equal ActiveSnapshot::Config.storage_method_yaml?, true
+    end
+
+    def teardown
+        ActiveSnapshot::Config.storage_method = @configured_storage_method
+    end
+
+    private
+
+    def switch_storage_method_to_json
+        ActiveSnapshot::Config.storage_method = 'json'
+    end
+end


### PR DESCRIPTION
Hello!

I'd love it to be merged into upstream. I've added configuration to switch between YAML and JSON storage types leaving the default with YAML. And on top of that a simple implementation to use PostgreSQL JSONB columns.

Cheers!