### PR TITLE
Add restore_first option to has_snapshot_children to fix foreign keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ class Post < ActiveRecord::Base
       
       ip_address: {
         record: instance.ip_address,
-        delete_method: ->(item){ item.release! }
+        delete_method: ->(item){ item.release! },
+        restore_first: true  # Restore first in case we are using foreign key
       }
     }
   end


### PR DESCRIPTION
Thanks for this gem. Much simpler to use than paper_trail, especially when you want to restore multiple items at once. I've got a suggestion that would be necessary to make it work for us. Maybe you want to include it.

When using foreign keys in the database you cannot always restore the item that created the snapshot first. For example: We have an `Order` which `has_many :order_items` where in turn each `belongs_to :order`. When I destroy the last `OrderItem` the `Order` is destroyed with it. When restoring the `OrderItem` validations are skipped. However, foreign keys will still prevent restore.

This PR adds the new option `restore_first`. When set to `true`, the corresponding records will be the first `snapshot_items` to be saved and thus later restored.

Let me know what you think!