### PR TITLE
Use ActiveRecord lazy loading

### DIFF
--- a/lib/active_snapshot.rb
+++ b/lib/active_snapshot.rb
@@ -1,28 +1,32 @@
-require "active_record"
-require "activerecord-import"
+require 'active_support/lazy_load_hooks'
 
 require "active_snapshot/version"
-require "active_snapshot/config"
 
-require "active_snapshot/models/snapshot"
-require "active_snapshot/models/snapshot_item"
+ActiveSupport.on_load(:active_record) do
+  require "activerecord-import"
 
-require "active_snapshot/models/concerns/snapshots_concern"
+  require "active_snapshot/config"
 
-module ActiveSnapshot
-  extend ActiveSupport::Concern
+  require "active_snapshot/models/snapshot"
+  require "active_snapshot/models/snapshot_item"
 
-  included do
-    include ActiveSnapshot::SnapshotsConcern
-  end
+  require "active_snapshot/models/concerns/snapshots_concern"
 
-  @@config = ActiveSnapshot::Config.new
+  module ActiveSnapshot
+    extend ActiveSupport::Concern
 
-  def self.config(&block)
-    if block_given?
-      block.call(@@config)
-    else
-      return @@config
+    included do
+      include ActiveSnapshot::SnapshotsConcern
+    end
+
+    @@config = ActiveSnapshot::Config.new
+
+    def self.config(&block)
+      if block_given?
+        block.call(@@config)
+      else
+        return @@config
+      end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 #$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 ENV["RAILS_ENV"] = "test"
 
+require "active_record"
 require "active_snapshot"
 
 if ENV["ACTIVE_SNAPSHOT_STORAGE_METHOD"].present?


### PR DESCRIPTION
Currently, the gem is loaded right away and requires active_record. When this happens, the database configuration is required even to run basic tasks like `assets:precompile` on a build host, which is suboptimal. There are two possible ways to prevent that:

1. Set `require: false` for the `active_snapshot` gem in Gemfile and add an initializer that lazy loads it:

    gem 'active_snapshot', '~> 0.3.0', require: false

```
ActiveSupport.on_load(:active_record) do
  require 'active_snapshot'
end
```
However, this will make the user required for a snapshot. I don't know why exactly but it looks like this is a bug anyway. In Rails 7, `belongs_to` will always add a presence validation. When lazy loading the gem, this actually works so the user is not optional anymore.

2. Merge this pull request. It will mark the user optional and lazy load all the code. Therefor, I had to move the requirement of `active_record' to `test_helper.rb`.