### PR TITLE
Add optional: true to Snapshot user relationship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 - **Unreleased**
   * [View Diff](https://github.com/westonganger/active_snapshot/compare/v0.3.0...master)
-  - Nothing yet
+  - Add `optional: true` to the Snapshot `belongs_to :user` relationship. Also added ActiveRecord model-level config option `belongs_to_required_by_default` to ensure belongs_to validations are enforced because Rails was ignoring the application config for `config.active_record.belongs_to_required_by_default`
 
 - **v0.3.0** - November 14, 2022
   * [View Diff](https://github.com/westonganger/active_snapshot/compare/v0.2.4...v0.3.0)
@@ -11,7 +11,7 @@ CHANGELOG
   * [PR #29](https://github.com/westonganger/active_snapshot/pull/29) - Deprecate :identifier argument as a positional argument
   * [PR #30](https://github.com/westonganger/active_snapshot/pull/30) - Make snapshot identifier optional
   * [PR #32](https://github.com/westonganger/active_snapshot/pull/26) - Add configuration option `ActiveSnapshot.config.storage_method = 'serialized_json'` with support for `serialized_json`, `serialized_yaml`, `native_json`
-  * [PR #32](https://github.com/westonganger/active_snapshot/pull/32) - Change default storage method from `serialized_yaml` to `serialized_json`. 
+  * [PR #32](https://github.com/westonganger/active_snapshot/pull/32) - Change default storage method from `serialized_yaml` to `serialized_json`.
   * [PR #32](https://github.com/westonganger/active_snapshot/pull/32) - `snapshot.metadata` and `snapshot_item.object` no longer return a HashWithIndifferentAccess. Now they simply return a regular Hash.
   * **Upgrade Instructions**
     * Change all instances of `create_snapshot!("my-snapshot-1"` to `create_snapshot!(identifier: "my-snapshot-1"`
@@ -46,7 +46,7 @@ CHANGELOG
   * Fix test suite
   * [View Diff](https://github.com/westonganger/active_snapshot/compare/v0.1.0...v0.1.1)
   * Nothing yet
-  
+
 - **v0.1.0** - Mar 5, 2021
   * [View Diff](https://github.com/westonganger/active_snapshot/compare/edbbfd3...v0.1.0)
   * Gem Initial Release

--- a/lib/active_snapshot/models/snapshot.rb
+++ b/lib/active_snapshot/models/snapshot.rb
@@ -2,11 +2,13 @@ module ActiveSnapshot
   class Snapshot < ActiveRecord::Base
     self.table_name = "snapshots"
 
+    self.belongs_to_required_by_default = true ### global config option not working, https://github.com/rails/rails/issues/27844
+
     if defined?(ProtectedAttributes)
       attr_accessible :item_id, :item_type, :identifier, :user_id, :user_type
     end
 
-    belongs_to :user, polymorphic: true
+    belongs_to :user, polymorphic: true, optional: true
     belongs_to :item, polymorphic: true
     has_many :snapshot_items, class_name: 'ActiveSnapshot::SnapshotItem', dependent: :destroy
 

--- a/lib/active_snapshot/models/snapshot_item.rb
+++ b/lib/active_snapshot/models/snapshot_item.rb
@@ -2,6 +2,8 @@ module ActiveSnapshot
   class SnapshotItem < ActiveRecord::Base
     self.table_name = "snapshot_items"
 
+    self.belongs_to_required_by_default = true ### global config option not working, https://github.com/rails/rails/issues/27844
+
     if defined?(ProtectedAttributes)
       attr_accessible :object, :item_id, :item_type, :child_group_name
     end

--- a/test/models/snapshot_item_test.rb
+++ b/test/models/snapshot_item_test.rb
@@ -30,11 +30,11 @@ class SnapshotItemTest < ActiveSupport::TestCase
 
   def test_validations
     instance = @snapshot_item_klass.new
-      
+
     instance.valid?
 
     [:item_id, :item_type, :snapshot_id].each do |attr|
-      assert instance.errors[attr].present? ### presence error
+      assert_equal ["can't be blank"], instance.errors[attr] ### presence error
     end
 
     shared_post = DATA[:shared_post]
@@ -42,14 +42,10 @@ class SnapshotItemTest < ActiveSupport::TestCase
 
     instance = @snapshot_item_klass.new(item: snapshot.item, snapshot: snapshot)
 
-    instance.valid?
+    assert_not instance.valid?
 
-    assert instance.errors[:item_id].present? ### uniq error
-    assert instance.errors[:item_type].present? ### uniq error
-
-    instance = @snapshot_item_klass.new(item_id: 1, item_type: 'Foobar', snapshot: snapshot)
-
-    assert instance.valid?
+    assert_equal ["has already been taken"], instance.errors[:item_id] ### uniq error
+    assert_equal ["has already been taken"], instance.errors[:item_type] ### uniq error
   end
 
   def test_object


### PR DESCRIPTION
Add `optional: true` to the Snapshot `belongs_to :user` relationship. 

Also added ActiveRecord model-level config option `belongs_to_required_by_default` to ensure belongs_to validations are enforced because Rails was ignoring the application config for `config.active_record.belongs_to_required_by_default`. See here for more details, https://github.com/rails/rails/pull/46047 (may be additional action items somewhere after that PR is merged)
