### PR TITLE
Utilize ActiveRecord lazy loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ CHANGELOG
 
 - **Unreleased**
   * [View Diff](https://github.com/westonganger/active_snapshot/compare/v0.3.0...master)
-  - Add `optional: true` to the Snapshot `belongs_to :user` relationship. Also added ActiveRecord model-level config option `belongs_to_required_by_default` to ensure belongs_to validations are enforced because Rails was ignoring the application config for `config.active_record.belongs_to_required_by_default`
+  * Allow ActiveRecord to be lazy loaded using `ActiveSupport.on_load`
+  * Add `optional: true` to the Snapshot `belongs_to :user` relationship. Also added ActiveRecord model-level config option `belongs_to_required_by_default` to ensure belongs_to validations are enforced because Rails was ignoring the application config for `config.active_record.belongs_to_required_by_default`
 
 - **v0.3.0** - November 14, 2022
   * [View Diff](https://github.com/westonganger/active_snapshot/compare/v0.2.4...v0.3.0)

--- a/lib/active_snapshot.rb
+++ b/lib/active_snapshot.rb
@@ -1,28 +1,31 @@
-require "active_record"
-require "activerecord-import"
-
 require "active_snapshot/version"
 require "active_snapshot/config"
 
-require "active_snapshot/models/snapshot"
-require "active_snapshot/models/snapshot_item"
+require 'active_support/lazy_load_hooks'
 
-require "active_snapshot/models/concerns/snapshots_concern"
+ActiveSupport.on_load(:active_record) do
+  require "activerecord-import"
 
-module ActiveSnapshot
-  extend ActiveSupport::Concern
+  require "active_snapshot/models/snapshot"
+  require "active_snapshot/models/snapshot_item"
 
-  included do
-    include ActiveSnapshot::SnapshotsConcern
-  end
+  require "active_snapshot/models/concerns/snapshots_concern"
 
-  @@config = ActiveSnapshot::Config.new
+  module ActiveSnapshot
+    extend ActiveSupport::Concern
 
-  def self.config(&block)
-    if block_given?
-      block.call(@@config)
-    else
-      return @@config
+    included do
+      include ActiveSnapshot::SnapshotsConcern
+    end
+
+    @@config = ActiveSnapshot::Config.new
+
+    def self.config(&block)
+      if block_given?
+        block.call(@@config)
+      else
+        return @@config
+      end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,8 @@
 #$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 ENV["RAILS_ENV"] = "test"
 
+require "active_support/all"
+
 require "active_snapshot"
 
 if ENV["ACTIVE_SNAPSHOT_STORAGE_METHOD"].present?


### PR DESCRIPTION
Currently, the gem is loaded right away and requires active_record. When this happens, the database configuration is required even to run basic tasks like assets:precompile on a build host, which is sub-optimal. Lazy loading active record is the correct thing to do for gems referencing ActiveRecord.