### PR TITLE
Remove redundant SnapshopItem item_type uniqueness validation

### DIFF
--- a/lib/active_snapshot/models/snapshot_item.rb
+++ b/lib/active_snapshot/models/snapshot_item.rb
@@ -13,7 +13,7 @@ module ActiveSnapshot
 
     validates :snapshot_id, presence: true
     validates :item_id, presence: true, uniqueness: { scope: [:snapshot_id, :item_type] }
-    validates :item_type, presence: true, uniqueness: { scope: [:snapshot_id, :item_id] }
+    validates :item_type, presence: true
 
     def object
       return @object if @object

--- a/test/models/snapshot_item_test.rb
+++ b/test/models/snapshot_item_test.rb
@@ -45,7 +45,6 @@ class SnapshotItemTest < ActiveSupport::TestCase
     assert_not instance.valid?
 
     assert_equal ["has already been taken"], instance.errors[:item_id] ### uniq error
-    assert_equal ["has already been taken"], instance.errors[:item_type] ### uniq error
   end
 
   def test_object


### PR DESCRIPTION
The uniqueness validation on item_type is redundant to the one for item_id