### PR TITLE
Remove dependency on activerecord-import using vanilla ActiveRecord upsert_all

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,6 @@ jobs:
           ### TEST RAILS VERSIONS
           - ruby: "2.6"
             env:
-              RAILS_VERSION: "5.2"
-          - ruby: "2.6"
-            env:
               RAILS_VERSION: "6.0"
           - ruby: "2.6"
             env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 - **Unreleased**
   * [View Diff](https://github.com/westonganger/active_snapshot/compare/v0.3.2...master)
-  * Nothing yet
+  * [#44](https://github.com/westonganger/active_snapshot/pull/44) - Remove dependency on activerecord-import with vanilla ActiveRecord upsert_all
 
 - **v0.3.2** - Oct 17, 2023
   * [View Diff](https://github.com/westonganger/active_snapshot/compare/v0.3.1...v0.3.2)

--- a/active_snapshot.gemspec
+++ b/active_snapshot.gemspec
@@ -17,17 +17,13 @@ Gem::Specification.new do |s|
   s.files = Dir.glob("{lib/**/*}") + %w{ LICENSE README.md Rakefile CHANGELOG.md }
   s.require_path = 'lib'
 
-  s.add_runtime_dependency "activerecord"
+  s.add_runtime_dependency "activerecord", ">= 6.0"
   s.add_runtime_dependency "railties"
-  s.add_runtime_dependency "activerecord-import"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "minitest"
   s.add_development_dependency "minitest-reporters"
   s.add_development_dependency "minitest-spec-rails"
   s.add_development_dependency "rspec-mocks"
-
-  if RUBY_VERSION.to_f >= 2.4
-    s.add_development_dependency "warning"
-  end
+  s.add_development_dependency "warning"
 end

--- a/lib/active_snapshot.rb
+++ b/lib/active_snapshot.rb
@@ -4,8 +4,6 @@ require "active_snapshot/config"
 require 'active_support/lazy_load_hooks'
 
 ActiveSupport.on_load(:active_record) do
-  require "activerecord-import"
-
   require "active_snapshot/models/snapshot"
   require "active_snapshot/models/snapshot_item"
 

--- a/lib/active_snapshot/models/concerns/snapshots_concern.rb
+++ b/lib/active_snapshot/models/concerns/snapshots_concern.rb
@@ -22,21 +22,23 @@ module ActiveSnapshot
         metadata: (metadata || {}),
       })
 
-      snapshot_items = []
+      new_entries = []
 
-      snapshot_items << snapshot.build_snapshot_item(self)
+      current_time = Time.now
+
+      new_entries << snapshot.build_snapshot_item(self).attributes.merge(created_at: current_time)
 
       snapshot_children = self.children_to_snapshot
 
       if snapshot_children
         snapshot_children.each do |child_group_name, h|
           h[:records].each do |child_item|
-            snapshot_items << snapshot.build_snapshot_item(child_item, child_group_name: child_group_name)
+            new_entries << snapshot.build_snapshot_item(child_item, child_group_name: child_group_name).attributes.merge(created_at: current_time)
           end
         end
       end
 
-      SnapshotItem.import(snapshot_items, validate: true)
+      SnapshotItem.upsert_all(new_entries.map{|x| x.delete("id"); x }, returning: false)
 
       snapshot
     end

--- a/test/dummy_app/config/application.rb
+++ b/test/dummy_app/config/application.rb
@@ -6,9 +6,7 @@ Bundler.require
 
 module Dummy
   class Application < Rails::Application
-    if Rails::VERSION::STRING.to_f >= 5.1
-      config.load_defaults Rails::VERSION::STRING.to_f
-    end
+    config.load_defaults Rails::VERSION::STRING.to_f
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,15 +15,11 @@ if ENV["ACTIVE_SNAPSHOT_STORAGE_METHOD"].present?
   ActiveSnapshot.config.storage_method = ENV["ACTIVE_SNAPSHOT_STORAGE_METHOD"]
 end
 
-begin
-  require 'warning'
+require 'warning'
 
-  Warning.ignore(
-    %r{mail/parsers/address_lists_parser}, ### Hide mail gem warnings
-  )
-rescue LoadError
-  # Do nothing
-end
+Warning.ignore(
+  %r{mail/parsers/address_lists_parser}, ### Hide mail gem warnings
+)
 
 ### Delete the database completely before starting
 FileUtils.rm(


### PR DESCRIPTION
There is no need for the extra dependency when Rails already has a built-in method `upsert_all`.

This means this gem requires a minimum of ActiveRecord v6.0 to work.