### PR TITLE
Allow ActiveSnapshot.config to be called before ActiveRecord on_load hook has occurred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ CHANGELOG
 
 - **Unreleased**
   * [View Diff](https://github.com/westonganger/active_snapshot/compare/v0.4.0...master)
-  * [#xx]((https://github.com/westonganger/active_snapshot/pull/xx) Remove :identifier argument as a positional argument
+  * [#53](https://github.com/westonganger/active_snapshot/pull/53) - Allow `ActiveSnapshot.config` to be called before ActiveRecord on_load hook has occurred
+  * [#52]((https://github.com/westonganger/active_snapshot/pull/52) Remove :identifier argument as a positional argument
 
 - **v0.4.0** - July 23, 2024
   * [View Diff](https://github.com/westonganger/active_snapshot/compare/v0.3.2...v0.4.0)

--- a/lib/active_snapshot.rb
+++ b/lib/active_snapshot.rb
@@ -3,27 +3,29 @@ require "active_snapshot/config"
 
 require 'active_support/lazy_load_hooks'
 
+module ActiveSnapshot
+  @@config = ActiveSnapshot::Config.new
+
+  def self.config(&block)
+    if block_given?
+      block.call(@@config)
+    else
+      return @@config
+    end
+  end
+end
+
 ActiveSupport.on_load(:active_record) do
   require "active_snapshot/models/snapshot"
   require "active_snapshot/models/snapshot_item"
 
   require "active_snapshot/models/concerns/snapshots_concern"
 
-  module ActiveSnapshot
+  ActiveSnapshot.module_eval do
     extend ActiveSupport::Concern
 
     included do
       include ActiveSnapshot::SnapshotsConcern
-    end
-
-    @@config = ActiveSnapshot::Config.new
-
-    def self.config(&block)
-      if block_given?
-        block.call(@@config)
-      else
-        return @@config
-      end
     end
   end
 end

--- a/test/models/snapshot_test.rb
+++ b/test/models/snapshot_test.rb
@@ -42,7 +42,7 @@ class SnapshotTest < ActiveSupport::TestCase
     snapshot = shared_post.snapshots.first
 
     instance = @snapshot_klass.new
-      
+
     instance.valid?
 
     [:item_id, :item_type].each do |attr|
@@ -67,7 +67,11 @@ class SnapshotTest < ActiveSupport::TestCase
 
     @snapshot.metadata = {foo: :bar}
 
-    assert_equal "bar", @snapshot.metadata['foo']
+    if ActiveSnapshot.config.storage_method_yaml?
+      assert_equal :bar, @snapshot.metadata.fetch(:foo)
+    else
+      assert_equal "bar", @snapshot.metadata.fetch("foo")
+    end
   end
 
   def test_build_snapshot_item
@@ -139,7 +143,11 @@ class SnapshotTest < ActiveSupport::TestCase
     prev_time_attrs = prev_attrs.extract!("created_at","updated_at")
     new_time_attrs = new_attrs.extract!("created_at","updated_at")
 
-    assert_equal new_time_attrs.values.map{|x| x.round(3)}, new_time_attrs.values
+    if ActiveSnapshot.config.storage_method_yaml?
+      assert_equal new_time_attrs.values.map{|x| x.round(6)}, new_time_attrs.values
+    else
+      assert_equal new_time_attrs.values.map{|x| x.round(3)}, new_time_attrs.values
+    end
 
     ### rounding to 3 sometimes fails due to millisecond precision so we just test for 2 decimal places here
     assert_equal prev_time_attrs.values.map{|x| x.round(2)}, new_time_attrs.values.map{|x| x.round(2)}

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -12,6 +12,10 @@ class ActiveSnapshot::ConfigTest < ActiveSupport::TestCase
     end
 
     def test_defaults_to_serialized_json
+      if ENV["ACTIVE_SNAPSHOT_STORAGE_METHOD"].present?
+        skip
+      end
+
       assert_equal 'serialized_json', ActiveSnapshot.config.storage_method
 
       assert_equal false, ActiveSnapshot.config.storage_method_yaml?
@@ -51,10 +55,11 @@ class ActiveSnapshot::ConfigTest < ActiveSupport::TestCase
     end
 
     def test_config_doesnt_accept_not_specified_storage_methods
+      assert ActiveSnapshot.config.storage_method.present?
       assert_raise do
-        ActiveSnapshot.config.storage_method = 'foobar'
+        ActiveSnapshot.config.storage_method = "foobar"
       end
-      assert_equal "serialized_json", ActiveSnapshot.config.storage_method
+      refute_equal "foobar", ActiveSnapshot.config.storage_method
     end
 
     def test_converts_symbol_to_string


### PR DESCRIPTION
Prevents errors in application initializers using `ActiveSnapshot.config` like

```
undefined method `config' for module ActiveSnapshot (NoMethodError)
```

Also resolves failures in the test suite regarding different storage_method configs