### PR TITLE
Add presence validation for object in SnapshotItem model

### DIFF
--- a/lib/active_snapshot/models/snapshot_item.rb
+++ b/lib/active_snapshot/models/snapshot_item.rb
@@ -18,13 +18,13 @@ module ActiveSnapshot
       return @object if @object
 
       if ActiveSnapshot.config.storage_method_json?
-        @object = super() ? JSON.parse(super()) : {}
+        @object = super ? JSON.parse(super) : {}
       elsif ActiveSnapshot.config.storage_method_yaml?
         yaml_method = YAML.respond_to?(:unsafe_load) ? :unsafe_load : :load
 
-        @object = super() ? YAML.public_send(yaml_method, super()) : {}
+        @object = super ? YAML.public_send(yaml_method, super) : {}
       elsif ActiveSnapshot.config.storage_method_native_json?
-        @object = super()
+        @object = super
       else
         raise StandardError, "Unsupported storage_method: `#{ActiveSnapshot.config.storage_method}`"
       end

--- a/lib/active_snapshot/models/snapshot_item.rb
+++ b/lib/active_snapshot/models/snapshot_item.rb
@@ -14,8 +14,7 @@ module ActiveSnapshot
     validates :item_type, presence: true
     validates :object, presence: true
 
-    def object(raw: false)
-      return super() if raw
+    def object
       return @object if @object
 
       if ActiveSnapshot.config.storage_method_json?

--- a/lib/active_snapshot/models/snapshot_item.rb
+++ b/lib/active_snapshot/models/snapshot_item.rb
@@ -26,7 +26,7 @@ module ActiveSnapshot
       elsif ActiveSnapshot.config.storage_method_native_json?
         @object = super()
       else
-        raise ArgumentError, "Unsupported storage_method: `#{ActiveSnapshot.config.storage_method}`"
+        raise StandardError, "Unsupported storage_method: `#{ActiveSnapshot.config.storage_method}`"
       end
     end
 

--- a/lib/active_snapshot/models/snapshot_item.rb
+++ b/lib/active_snapshot/models/snapshot_item.rb
@@ -12,22 +12,22 @@ module ActiveSnapshot
     validates :snapshot_id, presence: true
     validates :item_id, presence: true, uniqueness: { scope: [:snapshot_id, :item_type] }
     validates :item_type, presence: true
+    validates :object, presence: true
 
-    def object
+    def object(raw: false)
+      return super() if raw
       return @object if @object
 
       if ActiveSnapshot.config.storage_method_json?
-        @object = JSON.parse(self[:object])
+        @object = super() ? JSON.parse(super()) : {}
       elsif ActiveSnapshot.config.storage_method_yaml?
-        yaml_method = "unsafe_load"
+        yaml_method = YAML.respond_to?(:unsafe_load) ? :unsafe_load : :load
 
-        if !YAML.respond_to?("unsafe_load")
-          yaml_method = "load"
-        end
-
-        @object = YAML.send(yaml_method, self[:object])
+        @object = super() ? YAML.public_send(yaml_method, super()) : {}
       elsif ActiveSnapshot.config.storage_method_native_json?
-        @object = self[:object]
+        @object = super()
+      else
+        raise ArgumentError, "Unsupported storage_method: `#{ActiveSnapshot.config.storage_method}`"
       end
     end
 

--- a/lib/active_snapshot/models/snapshot_item.rb
+++ b/lib/active_snapshot/models/snapshot_item.rb
@@ -18,13 +18,13 @@ module ActiveSnapshot
       return @object if @object
 
       if ActiveSnapshot.config.storage_method_json?
-        @object = super ? JSON.parse(super) : {}
+        @object = self[:object] ? JSON.parse(self[:object]) : {}
       elsif ActiveSnapshot.config.storage_method_yaml?
         yaml_method = YAML.respond_to?(:unsafe_load) ? :unsafe_load : :load
 
-        @object = super ? YAML.public_send(yaml_method, super) : {}
+        @object = self[:object] ? YAML.public_send(yaml_method, self[:object]) : {}
       elsif ActiveSnapshot.config.storage_method_native_json?
-        @object = super
+        @object = self[:object]
       else
         raise StandardError, "Unsupported storage_method: `#{ActiveSnapshot.config.storage_method}`"
       end

--- a/test/models/snapshot_item_test.rb
+++ b/test/models/snapshot_item_test.rb
@@ -20,12 +20,23 @@ class SnapshotItemTest < ActiveSupport::TestCase
       instance.snapshot = instance
     end
 
-    instance.snapshot = ActiveSnapshot::Snapshot.new
+    instance.snapshot = @snapshot_klass.new
 
     instance.item = instance
 
     assert_not instance.snapshot.nil?
     assert_not instance.item.nil?
+  end
+
+  def test_object_validation
+    %w[serialized_yaml native_json serialized_json].each do |storage_strategy|
+      ActiveSnapshot.config.storage_method = storage_strategy
+      instance = @snapshot_item_klass.new
+
+      assert instance.invalid?
+
+      assert_equal ["can't be blank"], instance.errors[:object]
+    end
   end
 
   def test_validations

--- a/test/models/snapshot_item_test.rb
+++ b/test/models/snapshot_item_test.rb
@@ -28,23 +28,12 @@ class SnapshotItemTest < ActiveSupport::TestCase
     assert_not instance.item.nil?
   end
 
-  def test_object_validation
-    %w[serialized_yaml native_json serialized_json].each do |storage_strategy|
-      ActiveSnapshot.config.storage_method = storage_strategy
-      instance = @snapshot_item_klass.new
-
-      assert instance.invalid?
-
-      assert_equal ["can't be blank"], instance.errors[:object]
-    end
-  end
-
   def test_validations
     instance = @snapshot_item_klass.new
 
-    instance.valid?
+    assert instance.invalid?
 
-    [:item_id, :item_type, :snapshot_id].each do |attr|
+    %i[item_id item_type snapshot_id object].each do |attr|
       assert_equal ["can't be blank"], instance.errors[attr] ### presence error
     end
 
@@ -53,7 +42,7 @@ class SnapshotItemTest < ActiveSupport::TestCase
 
     instance = @snapshot_item_klass.new(item: snapshot.item, snapshot: snapshot)
 
-    assert_not instance.valid?
+    assert instance.invalid?
 
     assert_equal ["has already been taken"], instance.errors[:item_id] ### uniq error
   end

--- a/test/models/snapshot_item_test.rb
+++ b/test/models/snapshot_item_test.rb
@@ -33,7 +33,7 @@ class SnapshotItemTest < ActiveSupport::TestCase
 
     assert instance.invalid?
 
-    %i[item_id item_type snapshot_id object].each do |attr|
+    [:item_id, :item_type, :snapshot_id, :object].each do |attr|
       assert_equal ["can't be blank"], instance.errors[attr] ### presence error
     end
 


### PR DESCRIPTION
#51

**Improved Data Integrity**
By adding `validates :object, presence: true`, you ensure that the object attribute cannot be null or empty when a `SnapshotItem` is created or updated. This helps maintain data integrity and prevents situations where object might be inadvertently left empty.

**Error Handling for Unsupported Storage Methods**
An explicit error is raised if an unsupported `storage_method` is used, making it clear when configuration issues occur and preventing unexpected behavior.