### PR TITLE
Ensure snapshot record returned by `create_snapshot!` is `valid?`

### DIFF
--- a/lib/active_snapshot/models/concerns/snapshots_concern.rb
+++ b/lib/active_snapshot/models/concerns/snapshots_concern.rb
@@ -33,6 +33,8 @@ module ActiveSnapshot
       end
 
       SnapshotItem.upsert_all(new_entries.map{|x| x.delete("id"); x }, returning: false)
+      # reset the snapshot_items association so that the new snapshot items are loaded
+      snapshot.snapshot_items.reset
 
       snapshot
     end

--- a/test/models/snapshots_concern_test.rb
+++ b/test/models/snapshots_concern_test.rb
@@ -124,4 +124,12 @@ class SnapshotsConcernTest < ActiveSupport::TestCase
     end
   end
 
+  def test_create_snapshot_returns_valid_snapshot
+    post = Post.first
+
+    snapshot = post.create_snapshot!
+
+    assert snapshot.valid?
+  end
+
 end


### PR DESCRIPTION
This ensures the returned snapshot record is valid.

`SnapshotItem` has a uniqueness validation on `item_id`. This causes the snapshot to be invalid after all `SnapshotItems` have been saved to the database via `upsert_all`. All records instantiated with `Snapshot#build_snapshot_item` are still in their initial unsaved state. 