### PR TITLE
Fix: Hash.fetch(v) resulting in `KeyError: key not found: nil`

### DIFF
--- a/lib/active_snapshot/models/snapshot.rb
+++ b/lib/active_snapshot/models/snapshot.rb
@@ -48,7 +48,7 @@ module ActiveSnapshot
     def build_snapshot_item(instance, child_group_name: nil)
       attributes = instance.attributes
       attributes.each do |k, v|
-        if instance.class.defined_enums.key?(k)
+        if instance.class.defined_enums.key?(k) && v.present?
           attributes[k] = instance.class.defined_enums.fetch(k).fetch(v)
         end
       end

--- a/test/models/snapshot_test.rb
+++ b/test/models/snapshot_test.rb
@@ -90,12 +90,21 @@ class SnapshotTest < ActiveSupport::TestCase
 
   def test_build_snapshot_item_stores_enum_database_value
     @snapshot = @snapshot_klass.first
+    post = Post.first
 
-    snapshot_item = @snapshot.build_snapshot_item(Post.first)
+    snapshot_item = @snapshot.build_snapshot_item(post)
 
     assert snapshot_item.object['status'] == 0
 
     assert_equal @snapshot.snapshot_items.first.object['status'], snapshot_item.object['status']
+
+    # Test for enum value nil
+    post.status = nil
+
+    snapshot_item = @snapshot.build_snapshot_item(post)
+
+    assert snapshot_item.object['status'].nil?
+    assert_equal @snapshot.snapshot_items.last.object['status'], snapshot_item.object['status']
   end
 
   def test_restore


### PR DESCRIPTION
If an enum value is set to nil the snapshot creation fails.