### PR TITLE
On restore bypass assignment for snapshot object data where the associated column no longer exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 - **Unreleased**
   * [View Diff](https://github.com/westonganger/active_snapshot/compare/v0.5.0...master)
+  * [#66](https://github.com/westonganger/active_snapshot/pull/66) - Ensure `SnapshotItem#restore_item!` and `Snapshot#fetch_reified_items` bypass assignment for snapshot object data where the associated column no longer exists.
   * [#63](https://github.com/westonganger/active_snapshot/pull/63) - Fix bug when enum value is nil
 
 - **v0.5.0** - Nov 8, 2024

--- a/lib/active_snapshot/models/snapshot.rb
+++ b/lib/active_snapshot/models/snapshot.rb
@@ -112,7 +112,15 @@ module ActiveSnapshot
       reified_parent = nil
 
       snapshot_items.each do |si|
-        reified_item = si.item_type.constantize.new(si.object)
+        reified_item = si.item_type.constantize.new
+
+        si.object.each do |k,v|
+          if reified_item.respond_to?("#{k}=")
+            reified_item[k] = v
+          else
+            # database column was likely dropped since the snapshot was created
+          end
+        end
 
         if readonly
           reified_item.readonly!

--- a/lib/active_snapshot/models/snapshot_item.rb
+++ b/lib/active_snapshot/models/snapshot_item.rb
@@ -51,7 +51,13 @@ module ActiveSnapshot
         self.item = item_klass.new
       end
 
-      item.assign_attributes(object)
+      object.each do |k,v|
+        if item.respond_to?("#{k}=")
+          item[k] = v
+        else
+          # database column was likely dropped since the snapshot was created
+        end
+      end
 
       item.save!(validate: false, touch: false)
     end

--- a/test/models/snapshot_item_test.rb
+++ b/test/models/snapshot_item_test.rb
@@ -67,4 +67,17 @@ class SnapshotItemTest < ActiveSupport::TestCase
     @snapshot_item.restore_item!
   end
 
+  def test_restore_item_handles_dropped_columns!
+    snapshot = @snapshot_klass.includes(:snapshot_items).first
+
+    snapshot_item = snapshot.snapshot_items.first
+
+    attrs = snapshot_item.object
+    attrs["foo"] = "bar"
+
+    snapshot_item.update!(object: attrs)
+
+    snapshot_item.restore_item!
+  end
+
 end

--- a/test/models/snapshot_test.rb
+++ b/test/models/snapshot_test.rb
@@ -192,6 +192,19 @@ class SnapshotTest < ActiveSupport::TestCase
     assert_equal comment_content, reified_items.second[:comments].first.content
   end
 
+  def test_fetch_reified_items_handles_dropped_columns!
+    snapshot = @snapshot_klass.first
+
+    snapshot_item = snapshot.snapshot_items.first
+
+    attrs = snapshot_item.object
+    attrs["foo"] = "bar"
+
+    snapshot_item.update!(object: attrs)
+
+    reified_items = snapshot.fetch_reified_items(readonly: false)
+  end
+
   def test_single_model_snapshots_without_children
     instance = ParentWithoutChildren.create!({a: 1, b: 2})
 


### PR DESCRIPTION
Ensure `SnapshotItem#restore_item!` and `Snapshot#fetch_reified_items` bypass assignment for snapshot object data where the associated column no longer exists.

Solves #58 