### PR TITLE
Ensure no exception is raised when class does not have method defined_enums

### DIFF
--- a/lib/active_snapshot/models/snapshot.rb
+++ b/lib/active_snapshot/models/snapshot.rb
@@ -164,7 +164,7 @@ module ActiveSnapshot
     def build_snapshot_item(instance, child_group_name: nil)
       attrs = instance.attributes
 
-      if instance.class.defined_enums.any?
+      if instance.class.respond_to?(:defined_enums) && instance.class.defined_enums.any?
         instance.class.defined_enums.slice(*attrs.keys).each do |enum_col_name, enum_mapping|
           val = attrs.fetch(enum_col_name)
           next if val.nil?


### PR DESCRIPTION
This is a small suggested change to check the snapshot's instance class for the `defined_enums` method. 

I ran into this in my own application that includes ActiveStorage attachments in my model's snapshot children. `ActiveStorage::Attached::One` does not respond to `defined_enums` and was raising an error. 

I found from [this old issue comment](https://github.com/rails/rails/issues/31775#issuecomment-359917285) that `defined_enums` is a private API method, so maybe we should not rely on it always being available. 

I didn't include tests here as to not introduce a new model to the dummy app for this simple check, but happy to do that if you feel it's necessary. 

Thank you for this gem! It's been very helpful. 