### PR TITLE
Ensure snapshots store encrypted attributes in encrypted format

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,6 @@ jobs:
           - ruby: "3.4"
           - ruby: "4.0"
           ### TEST RAILS VERSIONS
-          - ruby: "2.6"
-            rails_version: "~> 6.1.0"
           - ruby: "4.0"
             rails_version: "~> 7.0.0"
             db_gem_version: "~> 1.4" # fixes sqlite3 gem dependency issue

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
       matrix:
         include:
           ### TEST RUBY VERSIONS
-          - ruby: "2.6"
           - ruby: "2.7"
           - ruby: "3.0"
             db_gem_version: "~> 1.4" # fixes sqlite3 gem dependency issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ CHANGELOG
 
 - **Unreleased**
   * [View Diff](https://github.com/westonganger/active_snapshot/compare/v1.1.0...master)
-  * Nothing yet
+  * [#80](https://github.com/westonganger/active_snapshot/pull/80)
+    * Encrypted fields are now also encrypted in snapshots.
+    * Drop support for rails < 7.0
 
 - **v1.1.0** - Dec 28 2025
   * [View Diff](https://github.com/westonganger/active_snapshot/compare/v1.0.0...v1.1.0)

--- a/active_snapshot.gemspec
+++ b/active_snapshot.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir.glob("{lib/**/*}") + %w{ LICENSE README.md Rakefile CHANGELOG.md }
   s.require_path = 'lib'
 
-  s.add_runtime_dependency "activerecord", ">= 6.1"
+  s.add_runtime_dependency "activerecord", ">= 7"
   s.add_runtime_dependency "railties"
 
   s.add_development_dependency "rake"

--- a/lib/active_snapshot.rb
+++ b/lib/active_snapshot.rb
@@ -13,6 +13,18 @@ module ActiveSnapshot
       return @@config
     end
   end
+
+  def self.deserialize_snapshot_value(klass, key:, value:)
+    return value if value.nil?
+    klass.attribute_types[key].deserialize(value)
+  rescue => e
+    if defined?(ActiveRecord::Encryption::Errors::Base) &&
+       e.is_a?(ActiveRecord::Encryption::Errors::Base)
+      value
+    else
+      raise
+    end
+  end
 end
 
 ActiveSupport.on_load(:active_record) do

--- a/lib/active_snapshot.rb
+++ b/lib/active_snapshot.rb
@@ -17,13 +17,8 @@ module ActiveSnapshot
   def self.deserialize_snapshot_value(klass, key:, value:)
     return value if value.nil?
     klass.attribute_types[key].deserialize(value)
-  rescue => e
-    if defined?(ActiveRecord::Encryption::Errors::Base) &&
-       e.is_a?(ActiveRecord::Encryption::Errors::Base)
-      value
-    else
-      raise
-    end
+  rescue ActiveRecord::Encryption::Errors::Base
+    value
   end
 end
 

--- a/lib/active_snapshot.rb
+++ b/lib/active_snapshot.rb
@@ -14,7 +14,7 @@ module ActiveSnapshot
     end
   end
 
-  def self.get_value(klass, key:, value:)
+  def self.get_deserialized_value(klass, key:, value:)
     return value if value.nil?
     
     begin

--- a/lib/active_snapshot.rb
+++ b/lib/active_snapshot.rb
@@ -14,11 +14,15 @@ module ActiveSnapshot
     end
   end
 
-  def self.deserialize_snapshot_value(klass, key:, value:)
+  def self.get_value(klass, key:, value:)
     return value if value.nil?
-    klass.attribute_types[key].deserialize(value)
-  rescue ActiveRecord::Encryption::Errors::Base
-    value
+    
+    begin
+      klass.attribute_types[key].deserialize(value)
+    # handle columns which are changed from non-encrypted to encrypted
+    rescue ActiveRecord::Encryption::Errors::Base
+      value
+    end
   end
 end
 

--- a/lib/active_snapshot/models/snapshot.rb
+++ b/lib/active_snapshot/models/snapshot.rb
@@ -118,8 +118,8 @@ module ActiveSnapshot
         changes = {}
 
         keys.each do |key|
-          from_value = ActiveSnapshot.deserialize_snapshot_value(item_class, key: key, value: from_object[key])
-          to_value = ActiveSnapshot.deserialize_snapshot_value(item_class, key: key, value: to_object[key])
+          from_value = ActiveSnapshot.get_value(item_class, key: key, value: from_object[key])
+          to_value = ActiveSnapshot.get_value(item_class, key: key, value: to_object[key])
 
           next if to_value == from_value
 
@@ -228,7 +228,7 @@ module ActiveSnapshot
 
         si.object.each do |k,v|
           if reified_item.respond_to?("#{k}=")
-            reified_item[k] = ActiveSnapshot.deserialize_snapshot_value(item_class, key: k, value: v)
+            reified_item[k] = ActiveSnapshot.get_value(item_class, key: k, value: v)
           else
             # database column was likely dropped since the snapshot was created
           end

--- a/lib/active_snapshot/models/snapshot.rb
+++ b/lib/active_snapshot/models/snapshot.rb
@@ -118,8 +118,8 @@ module ActiveSnapshot
         changes = {}
 
         keys.each do |key|
-          from_value = ActiveSnapshot.get_value(item_class, key: key, value: from_object[key])
-          to_value = ActiveSnapshot.get_value(item_class, key: key, value: to_object[key])
+          from_value = ActiveSnapshot.get_deserialized_value(item_class, key: key, value: from_object[key])
+          to_value = ActiveSnapshot.get_deserialized_value(item_class, key: key, value: to_object[key])
 
           next if to_value == from_value
 
@@ -228,7 +228,7 @@ module ActiveSnapshot
 
         si.object.each do |k,v|
           if reified_item.respond_to?("#{k}=")
-            reified_item[k] = ActiveSnapshot.get_value(item_class, key: k, value: v)
+            reified_item[k] = ActiveSnapshot.get_deserialized_value(item_class, key: k, value: v)
           else
             # database column was likely dropped since the snapshot was created
           end

--- a/lib/active_snapshot/models/snapshot.rb
+++ b/lib/active_snapshot/models/snapshot.rb
@@ -110,13 +110,16 @@ module ActiveSnapshot
         from_object = from ? from.object : {}
         to_object = to ? to.object : {}
 
+        item_type = (from || to).item_type
+        item_class = item_type.constantize
+
         keys = (from_object.keys + to_object.keys).uniq
 
         changes = {}
 
         keys.each do |key|
-          from_value = from_object[key]
-          to_value = to_object[key]
+          from_value = ActiveSnapshot.deserialize_snapshot_value(item_class, key: key, value: from_object[key])
+          to_value = ActiveSnapshot.deserialize_snapshot_value(item_class, key: key, value: to_object[key])
 
           next if to_value == from_value
 
@@ -162,13 +165,19 @@ module ActiveSnapshot
     end
 
     def build_snapshot_item(instance, child_group_name: nil)
-      attrs = instance.attributes
+      if instance.respond_to?(:attributes_for_database)
+        attrs = instance.attributes_for_database
+      else
+        # Fallback for Rails 6.x; attributes_for_database was added in Rails 7.0.
+        # This branch can be removed once Rails 6.x support is dropped.
+        attrs = instance.attributes
 
-      if instance.class.respond_to?(:defined_enums) && instance.class.defined_enums.any?
-        instance.class.defined_enums.slice(*attrs.keys).each do |enum_col_name, enum_mapping|
-          val = attrs.fetch(enum_col_name)
-          next if val.nil?
-          attrs[enum_col_name] = enum_mapping.fetch(val)
+        if instance.class.respond_to?(:defined_enums) && instance.class.defined_enums.any?
+          instance.class.defined_enums.slice(*attrs.keys).each do |enum_col_name, enum_mapping|
+            val = attrs.fetch(enum_col_name)
+            next if val.nil?
+            attrs[enum_col_name] = enum_mapping.fetch(val)
+          end
         end
       end
 
@@ -228,11 +237,12 @@ module ActiveSnapshot
       reified_parent = nil
 
       snapshot_items.each do |si|
-        reified_item = si.item_type.constantize.new
+        item_class = si.item_type.constantize
+        reified_item = item_class.new
 
         si.object.each do |k,v|
           if reified_item.respond_to?("#{k}=")
-            reified_item[k] = v
+            reified_item[k] = ActiveSnapshot.deserialize_snapshot_value(item_class, key: k, value: v)
           else
             # database column was likely dropped since the snapshot was created
           end

--- a/lib/active_snapshot/models/snapshot.rb
+++ b/lib/active_snapshot/models/snapshot.rb
@@ -165,21 +165,7 @@ module ActiveSnapshot
     end
 
     def build_snapshot_item(instance, child_group_name: nil)
-      if instance.respond_to?(:attributes_for_database)
-        attrs = instance.attributes_for_database
-      else
-        # Fallback for Rails 6.x; attributes_for_database was added in Rails 7.0.
-        # This branch can be removed once Rails 6.x support is dropped.
-        attrs = instance.attributes
-
-        if instance.class.respond_to?(:defined_enums) && instance.class.defined_enums.any?
-          instance.class.defined_enums.slice(*attrs.keys).each do |enum_col_name, enum_mapping|
-            val = attrs.fetch(enum_col_name)
-            next if val.nil?
-            attrs[enum_col_name] = enum_mapping.fetch(val)
-          end
-        end
-      end
+      attrs = instance.attributes_for_database
 
       self.snapshot_items.new({
         object: attrs,

--- a/lib/active_snapshot/models/snapshot_item.rb
+++ b/lib/active_snapshot/models/snapshot_item.rb
@@ -55,7 +55,7 @@ module ActiveSnapshot
 
       object.each do |k,v|
         if item.respond_to?("#{k}=")
-          item[k] = ActiveSnapshot.get_value(item.class, key: k, value: v)
+          item[k] = ActiveSnapshot.get_deserialized_value(item.class, key: k, value: v)
         else
           # database column was likely dropped since the snapshot was created
         end

--- a/lib/active_snapshot/models/snapshot_item.rb
+++ b/lib/active_snapshot/models/snapshot_item.rb
@@ -55,7 +55,7 @@ module ActiveSnapshot
 
       object.each do |k,v|
         if item.respond_to?("#{k}=")
-          item[k] = v
+          item[k] = ActiveSnapshot.deserialize_snapshot_value(item.class, key: k, value: v)
         else
           # database column was likely dropped since the snapshot was created
         end

--- a/lib/active_snapshot/models/snapshot_item.rb
+++ b/lib/active_snapshot/models/snapshot_item.rb
@@ -55,7 +55,7 @@ module ActiveSnapshot
 
       object.each do |k,v|
         if item.respond_to?("#{k}=")
-          item[k] = ActiveSnapshot.deserialize_snapshot_value(item.class, key: k, value: v)
+          item[k] = ActiveSnapshot.get_value(item.class, key: k, value: v)
         else
           # database column was likely dropped since the snapshot was created
         end

--- a/test/dummy_app/app/models/comment.rb
+++ b/test/dummy_app/app/models/comment.rb
@@ -1,5 +1,9 @@
 class Comment < ActiveRecord::Base
   include ActiveSnapshot
 
+  if ActiveRecord::VERSION::MAJOR >= 7
+    encrypts :content
+  end
+
   belongs_to :post
 end

--- a/test/dummy_app/app/models/comment.rb
+++ b/test/dummy_app/app/models/comment.rb
@@ -1,9 +1,7 @@
 class Comment < ActiveRecord::Base
   include ActiveSnapshot
 
-  if ActiveRecord::VERSION::MAJOR >= 7
-    encrypts :content
-  end
+  encrypts :content
 
   belongs_to :post
 end

--- a/test/dummy_app/app/models/post.rb
+++ b/test/dummy_app/app/models/post.rb
@@ -1,11 +1,7 @@
 class Post < ActiveRecord::Base
   include ActiveSnapshot
 
-  if Rails::VERSION::MAJOR >= 7
-    enum :status, [:draft, :published]
-  else
-    enum status: [:draft, :published]
-  end
+  enum :status, [:draft, :published]
 
   has_many :comments
   has_many :notes

--- a/test/dummy_app/config/application.rb
+++ b/test/dummy_app/config/application.rb
@@ -36,6 +36,12 @@ module Dummy
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]
 
+    if ActiveRecord::VERSION::MAJOR >= 7
+      config.active_record.encryption.primary_key = "test-primary-key-thats-32-bytes"
+      config.active_record.encryption.deterministic_key = "test-deterministic-key-32-bytes!"
+      config.active_record.encryption.key_derivation_salt = "test-key-derivation-salt-value!!"
+    end
+
     config.generators.test_framework = false
     config.generators.helper = false
     config.generators.stylesheets = false

--- a/test/dummy_app/config/application.rb
+++ b/test/dummy_app/config/application.rb
@@ -36,11 +36,9 @@ module Dummy
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password]
 
-    if ActiveRecord::VERSION::MAJOR >= 7
-      config.active_record.encryption.primary_key = "test-primary-key-thats-32-bytes"
-      config.active_record.encryption.deterministic_key = "test-deterministic-key-32-bytes!"
-      config.active_record.encryption.key_derivation_salt = "test-key-derivation-salt-value!!"
-    end
+    config.active_record.encryption.primary_key = "test-primary-key-thats-32-bytes"
+    config.active_record.encryption.deterministic_key = "test-deterministic-key-32-bytes!"
+    config.active_record.encryption.key_derivation_salt = "test-key-derivation-salt-value!!"
 
     config.generators.test_framework = false
     config.generators.helper = false

--- a/test/models/snapshot_test.rb
+++ b/test/models/snapshot_test.rb
@@ -441,93 +441,89 @@ class SnapshotTest < ActiveSupport::TestCase
     end
   end
 
-  if ActiveRecord::VERSION::MAJOR >= 7
+  def test_snapshot_item_stores_encrypted_attribute_as_ciphertext
+    plaintext = "super secret comment"
+    post = Post.create!(a: 1, b: 2)
+    comment = post.comments.create!(content: plaintext)
 
-    def test_snapshot_item_stores_encrypted_attribute_as_ciphertext
-      plaintext = "super secret comment"
-      post = Post.create!(a: 1, b: 2)
-      comment = post.comments.create!(content: plaintext)
+    snapshot = post.create_snapshot!
 
-      snapshot = post.create_snapshot!
+    snapshot_item = snapshot.snapshot_items.find_by(item_type: "Comment", item_id: comment.id)
 
-      snapshot_item = snapshot.snapshot_items.find_by(item_type: "Comment", item_id: comment.id)
+    raw_value = ActiveRecord::Base.connection.select_value(
+      "SELECT object FROM snapshot_items WHERE id = #{snapshot_item.id}"
+    )
+    refute_includes raw_value.to_s, plaintext,
+      "Expected encrypted attribute to be stored as ciphertext, not plaintext"
 
-      raw_value = ActiveRecord::Base.connection.select_value(
-        "SELECT object FROM snapshot_items WHERE id = #{snapshot_item.id}"
-      )
-      refute_includes raw_value.to_s, plaintext,
-        "Expected encrypted attribute to be stored as ciphertext, not plaintext"
+    stored_object = snapshot_item.object
+    assert stored_object["content"].present?,
+      "Expected ciphertext to be present"
+  end
 
-      stored_object = snapshot_item.object
-      assert stored_object["content"].present?,
-        "Expected ciphertext to be present"
-    end
+  def test_fetch_reified_items_decrypts_encrypted_attributes
+    plaintext = "reify me correctly"
+    post = Post.create!(a: 1, b: 2)
+    post.comments.create!(content: plaintext)
 
-    def test_fetch_reified_items_decrypts_encrypted_attributes
-      plaintext = "reify me correctly"
-      post = Post.create!(a: 1, b: 2)
-      post.comments.create!(content: plaintext)
+    snapshot = post.create_snapshot!
 
-      snapshot = post.create_snapshot!
+    _reified_post, reified_children = snapshot.fetch_reified_items
 
-      _reified_post, reified_children = snapshot.fetch_reified_items
+    reified_comment = reified_children["comments"].first
+    assert_equal plaintext, reified_comment.content
+  end
 
-      reified_comment = reified_children["comments"].first
-      assert_equal plaintext, reified_comment.content
-    end
+  def test_restore_preserves_encrypted_attribute_value
+    original_content = "original secret"
+    post = Post.create!(a: 1, b: 2)
+    comment = post.comments.create!(content: original_content)
 
-    def test_restore_preserves_encrypted_attribute_value
-      original_content = "original secret"
-      post = Post.create!(a: 1, b: 2)
-      comment = post.comments.create!(content: original_content)
+    snapshot = post.create_snapshot!
 
-      snapshot = post.create_snapshot!
+    comment.update!(content: "changed secret")
+    assert_equal "changed secret", comment.reload.content
 
-      comment.update!(content: "changed secret")
-      assert_equal "changed secret", comment.reload.content
+    snapshot.restore!
 
-      snapshot.restore!
+    comment.reload
+    assert_equal original_content, comment.content
 
-      comment.reload
-      assert_equal original_content, comment.content
+    raw_value = ActiveRecord::Base.connection.select_value(
+      "SELECT content FROM comments WHERE id = #{comment.id}"
+    )
+    refute_equal original_content, raw_value,
+      "Expected DB column to contain ciphertext after restore, not plaintext"
+  end
 
-      raw_value = ActiveRecord::Base.connection.select_value(
-        "SELECT content FROM comments WHERE id = #{comment.id}"
-      )
-      refute_equal original_content, raw_value,
-        "Expected DB column to contain ciphertext after restore, not plaintext"
-    end
+  def test_snapshot_handles_nil_encrypted_attribute
+    post = Post.create!(a: 1, b: 2)
+    comment = post.comments.create!(content: nil)
 
-    def test_snapshot_handles_nil_encrypted_attribute
-      post = Post.create!(a: 1, b: 2)
-      comment = post.comments.create!(content: nil)
+    snapshot = post.create_snapshot!
 
-      snapshot = post.create_snapshot!
+    snapshot_item = snapshot.snapshot_items.find_by(item_type: "Comment", item_id: comment.id)
+    assert_nil snapshot_item.object["content"]
 
-      snapshot_item = snapshot.snapshot_items.find_by(item_type: "Comment", item_id: comment.id)
-      assert_nil snapshot_item.object["content"]
+    _reified_post, reified_children = snapshot.fetch_reified_items
+    assert_nil reified_children["comments"].first.content
+  end
 
-      _reified_post, reified_children = snapshot.fetch_reified_items
-      assert_nil reified_children["comments"].first.content
-    end
+  def test_snapshot_backward_compat_plaintext_encrypted_attribute
+    plaintext = "old plaintext from before encryption patch"
+    post = Post.create!(a: 1, b: 2)
+    comment = post.comments.create!(content: "placeholder")
 
-    def test_snapshot_backward_compat_plaintext_encrypted_attribute
-      plaintext = "old plaintext from before encryption patch"
-      post = Post.create!(a: 1, b: 2)
-      comment = post.comments.create!(content: "placeholder")
+    snapshot = post.create_snapshot!
 
-      snapshot = post.create_snapshot!
+    snapshot_item = snapshot.snapshot_items.find_by(item_type: "Comment", item_id: comment.id)
+    obj = snapshot_item.object
+    obj["content"] = plaintext
+    snapshot_item.update!(object: obj)
 
-      snapshot_item = snapshot.snapshot_items.find_by(item_type: "Comment", item_id: comment.id)
-      obj = snapshot_item.object
-      obj["content"] = plaintext
-      snapshot_item.update!(object: obj)
-
-      _reified_post, reified_children = snapshot.fetch_reified_items
-      reified_comment = reified_children["comments"].first
-      assert_equal plaintext, reified_comment.content
-    end
-
+    _reified_post, reified_children = snapshot.fetch_reified_items
+    reified_comment = reified_children["comments"].first
+    assert_equal plaintext, reified_comment.content
   end
 
 end

--- a/test/models/snapshot_test.rb
+++ b/test/models/snapshot_test.rb
@@ -452,13 +452,13 @@ class SnapshotTest < ActiveSupport::TestCase
 
       snapshot_item = snapshot.snapshot_items.find_by(item_type: "Comment", item_id: comment.id)
 
-      raw_json = ActiveRecord::Base.connection.select_value(
+      raw_value = ActiveRecord::Base.connection.select_value(
         "SELECT object FROM snapshot_items WHERE id = #{snapshot_item.id}"
       )
-      stored_object = JSON.parse(raw_json)
-
-      refute_equal plaintext, stored_object["content"],
+      refute_includes raw_value.to_s, plaintext,
         "Expected encrypted attribute to be stored as ciphertext, not plaintext"
+
+      stored_object = snapshot_item.object
       assert stored_object["content"].present?,
         "Expected ciphertext to be present"
     end

--- a/test/models/snapshot_test.rb
+++ b/test/models/snapshot_test.rb
@@ -441,4 +441,93 @@ class SnapshotTest < ActiveSupport::TestCase
     end
   end
 
+  if ActiveRecord::VERSION::MAJOR >= 7
+
+    def test_snapshot_item_stores_encrypted_attribute_as_ciphertext
+      plaintext = "super secret comment"
+      post = Post.create!(a: 1, b: 2)
+      comment = post.comments.create!(content: plaintext)
+
+      snapshot = post.create_snapshot!
+
+      snapshot_item = snapshot.snapshot_items.find_by(item_type: "Comment", item_id: comment.id)
+
+      raw_json = ActiveRecord::Base.connection.select_value(
+        "SELECT object FROM snapshot_items WHERE id = #{snapshot_item.id}"
+      )
+      stored_object = JSON.parse(raw_json)
+
+      refute_equal plaintext, stored_object["content"],
+        "Expected encrypted attribute to be stored as ciphertext, not plaintext"
+      assert stored_object["content"].present?,
+        "Expected ciphertext to be present"
+    end
+
+    def test_fetch_reified_items_decrypts_encrypted_attributes
+      plaintext = "reify me correctly"
+      post = Post.create!(a: 1, b: 2)
+      post.comments.create!(content: plaintext)
+
+      snapshot = post.create_snapshot!
+
+      _reified_post, reified_children = snapshot.fetch_reified_items
+
+      reified_comment = reified_children["comments"].first
+      assert_equal plaintext, reified_comment.content
+    end
+
+    def test_restore_preserves_encrypted_attribute_value
+      original_content = "original secret"
+      post = Post.create!(a: 1, b: 2)
+      comment = post.comments.create!(content: original_content)
+
+      snapshot = post.create_snapshot!
+
+      comment.update!(content: "changed secret")
+      assert_equal "changed secret", comment.reload.content
+
+      snapshot.restore!
+
+      comment.reload
+      assert_equal original_content, comment.content
+
+      raw_value = ActiveRecord::Base.connection.select_value(
+        "SELECT content FROM comments WHERE id = #{comment.id}"
+      )
+      refute_equal original_content, raw_value,
+        "Expected DB column to contain ciphertext after restore, not plaintext"
+    end
+
+    def test_snapshot_handles_nil_encrypted_attribute
+      post = Post.create!(a: 1, b: 2)
+      comment = post.comments.create!(content: nil)
+
+      snapshot = post.create_snapshot!
+
+      snapshot_item = snapshot.snapshot_items.find_by(item_type: "Comment", item_id: comment.id)
+      assert_nil snapshot_item.object["content"]
+
+      _reified_post, reified_children = snapshot.fetch_reified_items
+      assert_nil reified_children["comments"].first.content
+    end
+
+    def test_snapshot_backward_compat_plaintext_encrypted_attribute
+      plaintext = "old plaintext from before encryption patch"
+      post = Post.create!(a: 1, b: 2)
+      comment = post.comments.create!(content: "placeholder")
+
+      snapshot = post.create_snapshot!
+
+      snapshot_item = snapshot.snapshot_items.find_by(item_type: "Comment", item_id: comment.id)
+      obj = snapshot_item.object
+      obj["content"] = plaintext
+      snapshot_item.update!(object: obj)
+
+      _reified_post, reified_children = snapshot.fetch_reified_items
+      reified_comment = reified_children["comments"].first
+      assert_equal plaintext, reified_comment.content
+    end
+
+  end
+
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,11 +51,7 @@ Minitest::Reporters.use!(
 require "minitest/autorun"
 
 # Run any available migration
-if ActiveRecord::VERSION::MAJOR == 6
-  ActiveRecord::MigrationContext.new(File.expand_path("dummy_app/db/migrate/", __dir__), ActiveRecord::SchemaMigration).migrate
-else
-  ActiveRecord::MigrationContext.new(File.expand_path("dummy_app/db/migrate/", __dir__)).migrate
-end
+ActiveRecord::MigrationContext.new(File.expand_path("dummy_app/db/migrate/", __dir__)).migrate
 
 require "rspec/mocks/minitest_integration"
 

--- a/test/unit/active_snapshot_test.rb
+++ b/test/unit/active_snapshot_test.rb
@@ -10,31 +10,27 @@ class ActiveSnapshotTest < ActiveSupport::TestCase
     assert ActiveSnapshot::VERSION
   end
 
-  if ActiveRecord::VERSION::MAJOR >= 7
+  def test_deserialize_snapshot_value_decrypts_ciphertext
+    comment = Comment.create!(content: "secret", post: Post.first!)
+    ciphertext = comment.ciphertext_for(:content)
 
-    def test_deserialize_snapshot_value_decrypts_ciphertext
-      comment = Comment.create!(content: "secret", post: Post.first!)
-      ciphertext = comment.ciphertext_for(:content)
+    result = ActiveSnapshot.deserialize_snapshot_value(Comment, key: "content", value: ciphertext)
+    assert_equal "secret", result
+  end
 
-      result = ActiveSnapshot.deserialize_snapshot_value(Comment, key: "content", value: ciphertext)
-      assert_equal "secret", result
-    end
+  def test_deserialize_snapshot_value_falls_back_for_plaintext
+    result = ActiveSnapshot.deserialize_snapshot_value(Comment, key: "content", value: "raw plaintext")
+    assert_equal "raw plaintext", result
+  end
 
-    def test_deserialize_snapshot_value_falls_back_for_plaintext
-      result = ActiveSnapshot.deserialize_snapshot_value(Comment, key: "content", value: "raw plaintext")
-      assert_equal "raw plaintext", result
-    end
+  def test_deserialize_snapshot_value_returns_nil_for_nil
+    result = ActiveSnapshot.deserialize_snapshot_value(Comment, key: "content", value: nil)
+    assert_nil result
+  end
 
-    def test_deserialize_snapshot_value_returns_nil_for_nil
-      result = ActiveSnapshot.deserialize_snapshot_value(Comment, key: "content", value: nil)
-      assert_nil result
-    end
-
-    def test_deserialize_snapshot_value_deserializes_non_encrypted
-      result = ActiveSnapshot.deserialize_snapshot_value(Post, key: "title", value: "hello")
-      assert_equal "hello", result
-    end
-
+  def test_deserialize_snapshot_value_deserializes_non_encrypted
+    result = ActiveSnapshot.deserialize_snapshot_value(Post, key: "title", value: "hello")
+    assert_equal "hello", result
   end
 
   def test_snapshot_lifecycle

--- a/test/unit/active_snapshot_test.rb
+++ b/test/unit/active_snapshot_test.rb
@@ -10,26 +10,26 @@ class ActiveSnapshotTest < ActiveSupport::TestCase
     assert ActiveSnapshot::VERSION
   end
 
-  def test_deserialize_snapshot_value_decrypts_ciphertext
+  def test_get_value_decrypts_ciphertext
     comment = Comment.create!(content: "secret", post: Post.first!)
     ciphertext = comment.ciphertext_for(:content)
 
-    result = ActiveSnapshot.deserialize_snapshot_value(Comment, key: "content", value: ciphertext)
+    result = ActiveSnapshot.get_value(Comment, key: "content", value: ciphertext)
     assert_equal "secret", result
   end
 
-  def test_deserialize_snapshot_value_falls_back_for_plaintext
-    result = ActiveSnapshot.deserialize_snapshot_value(Comment, key: "content", value: "raw plaintext")
+  def test_get_value_falls_back_for_plaintext
+    result = ActiveSnapshot.get_value(Comment, key: "content", value: "raw plaintext")
     assert_equal "raw plaintext", result
   end
 
-  def test_deserialize_snapshot_value_returns_nil_for_nil
-    result = ActiveSnapshot.deserialize_snapshot_value(Comment, key: "content", value: nil)
+  def test_get_value_returns_nil_for_nil
+    result = ActiveSnapshot.get_value(Comment, key: "content", value: nil)
     assert_nil result
   end
 
-  def test_deserialize_snapshot_value_deserializes_non_encrypted
-    result = ActiveSnapshot.deserialize_snapshot_value(Post, key: "title", value: "hello")
+  def test_get_value_deserializes_non_encrypted
+    result = ActiveSnapshot.get_value(Post, key: "title", value: "hello")
     assert_equal "hello", result
   end
 

--- a/test/unit/active_snapshot_test.rb
+++ b/test/unit/active_snapshot_test.rb
@@ -10,6 +10,33 @@ class ActiveSnapshotTest < ActiveSupport::TestCase
     assert ActiveSnapshot::VERSION
   end
 
+  if ActiveRecord::VERSION::MAJOR >= 7
+
+    def test_deserialize_snapshot_value_decrypts_ciphertext
+      comment = Comment.create!(content: "secret", post: Post.first!)
+      ciphertext = comment.ciphertext_for(:content)
+
+      result = ActiveSnapshot.deserialize_snapshot_value(Comment, key: "content", value: ciphertext)
+      assert_equal "secret", result
+    end
+
+    def test_deserialize_snapshot_value_falls_back_for_plaintext
+      result = ActiveSnapshot.deserialize_snapshot_value(Comment, key: "content", value: "raw plaintext")
+      assert_equal "raw plaintext", result
+    end
+
+    def test_deserialize_snapshot_value_returns_nil_for_nil
+      result = ActiveSnapshot.deserialize_snapshot_value(Comment, key: "content", value: nil)
+      assert_nil result
+    end
+
+    def test_deserialize_snapshot_value_deserializes_non_encrypted
+      result = ActiveSnapshot.deserialize_snapshot_value(Post, key: "title", value: "hello")
+      assert_equal "hello", result
+    end
+
+  end
+
   def test_snapshot_lifecycle
     identifier = "snapshot-1"
 

--- a/test/unit/active_snapshot_test.rb
+++ b/test/unit/active_snapshot_test.rb
@@ -10,26 +10,26 @@ class ActiveSnapshotTest < ActiveSupport::TestCase
     assert ActiveSnapshot::VERSION
   end
 
-  def test_get_value_decrypts_ciphertext
+  def test_get_deserialized_value_decrypts_ciphertext
     comment = Comment.create!(content: "secret", post: Post.first!)
     ciphertext = comment.ciphertext_for(:content)
 
-    result = ActiveSnapshot.get_value(Comment, key: "content", value: ciphertext)
+    result = ActiveSnapshot.get_deserialized_value(Comment, key: "content", value: ciphertext)
     assert_equal "secret", result
   end
 
-  def test_get_value_falls_back_for_plaintext
-    result = ActiveSnapshot.get_value(Comment, key: "content", value: "raw plaintext")
+  def test_get_deserialized_value_falls_back_for_plaintext
+    result = ActiveSnapshot.get_deserialized_value(Comment, key: "content", value: "raw plaintext")
     assert_equal "raw plaintext", result
   end
 
-  def test_get_value_returns_nil_for_nil
-    result = ActiveSnapshot.get_value(Comment, key: "content", value: nil)
+  def test_get_deserialized_value_returns_nil_for_nil
+    result = ActiveSnapshot.get_deserialized_value(Comment, key: "content", value: nil)
     assert_nil result
   end
 
-  def test_get_value_deserializes_non_encrypted
-    result = ActiveSnapshot.get_value(Post, key: "title", value: "hello")
+  def test_get_deserialized_value_deserializes_non_encrypted
+    result = ActiveSnapshot.get_deserialized_value(Post, key: "title", value: "hello")
     assert_equal "hello", result
   end
 


### PR DESCRIPTION
## problem

my application has an encrypted column, which can store personal health information (PHI). 

i expected that snapshots would store the ciphertext, but actually i saw that the database contained the unencrypted data in plain text.

## solution in this PR

this PR updates both storage and retrieval of snapshots so that the snapshot item will store ciphertext instead of plaintext. 

**this change is transparent to application code, and should be completely backwards-compatible.**

we use [`attributes_for_database`](https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/BeforeTypeCast.html#method-i-attributes_for_database), which was added in Rails 7, and include fallback code for Rails 6 support.

## example

### before this change

```
psql> select object->>'protected_narrative' as data from snapshot_items where id = 1307;
    data
-------------
 protected 4
(1 row)
```

### with this change

```
psql> select object->>'protected_narrative' as data from snapshot_items where id = 1313;
                                              data
------------------------------------------------------------------------------------------------
 {"p":"GGlNq+Tg8Jm0YoouhYbWOw==","h":{"iv":"XsitWbz+8smUYdfH","at":"uYq8BD/SN+HL6zo5hXuVBw=="}}
(1 row)
```

## references

  * https://guides.rubyonrails.org/active_record_encryption.html
  * https://api.rubyonrails.org/classes/ActiveRecord/AttributeMethods/BeforeTypeCast.html#method-i-attributes_for_database