### PR TITLE
Remove Rails 6.x require logger fix from test helper

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,6 @@
 #$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 ENV["RAILS_ENV"] = "test"
 
-require "logger" # Fix for Rails 7.0 and below, https://github.com/rails/rails/pull/54264
-
 require "active_support/all"
 
 ActiveSupport.on_load(:active_record) do


### PR DESCRIPTION
Rails 6.x is no longer supported so we dont need this