### PR TITLE
Properly serialize postgres array columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 - **Unreleased**
   * [View Diff](https://github.com/westonganger/active_snapshot/compare/v1.2.0...master)
-  * Properly serialize PostgreSQL enum array columns to a JSON array
+  * Properly serialize PostgreSQL array columns to a JSON array
 
 - **v1.2.0** - Jun 25, 2026
   * [View Diff](https://github.com/westonganger/active_snapshot/compare/v1.1.0...v1.2.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 - **Unreleased**
   * [View Diff](https://github.com/westonganger/active_snapshot/compare/v1.2.0...master)
-  * Nothing yet
+  * Properly serialize PostgreSQL enum array columns to a JSON array
 
 - **v1.2.0** - Jun 25, 2026
   * [View Diff](https://github.com/westonganger/active_snapshot/compare/v1.1.0...v1.2.0)

--- a/lib/active_snapshot/models/snapshot.rb
+++ b/lib/active_snapshot/models/snapshot.rb
@@ -166,7 +166,7 @@ module ActiveSnapshot
 
     def build_snapshot_item(instance, child_group_name: nil)
       attrs = instance.attributes_for_database.transform_values do |value|
-        if value.try(:encoder).is_a?(PG::TextEncoder::Array)
+        if defined?(PG) && value.try(:encoder).is_a?(PG::TextEncoder::Array)
           value.values
         else
           value

--- a/lib/active_snapshot/models/snapshot.rb
+++ b/lib/active_snapshot/models/snapshot.rb
@@ -165,7 +165,13 @@ module ActiveSnapshot
     end
 
     def build_snapshot_item(instance, child_group_name: nil)
-      attrs = instance.attributes_for_database
+      attrs = instance.attributes_for_database.transform_values do |value|
+        if value.try(:encoder).is_a?(PG::TextEncoder::Array)
+          value.values
+        else
+          value
+        end
+      end
 
       self.snapshot_items.new({
         object: attrs,

--- a/test/dummy_app/db/migrate/20210128155312_set_up_test_tables.rb
+++ b/test/dummy_app/db/migrate/20210128155312_set_up_test_tables.rb
@@ -1,10 +1,18 @@
 class SetUpTestTables < ActiveRecord::Migration::Current
 
   def change
+    if connection.adapter_name == "PostgreSQL"
+      create_enum :post_enum_array, ["foo", "bar"]
+    end
+
     create_table :posts do |t|
       t.integer :a, :b
 
       t.integer :status, default: 0
+
+      if connection.adapter_name == "PostgreSQL"
+        t.enum :enum_array, enum_type: :post_enum_array, array: true
+      end
 
       t.timestamps
     end

--- a/test/dummy_app/db/migrate/20210128155312_set_up_test_tables.rb
+++ b/test/dummy_app/db/migrate/20210128155312_set_up_test_tables.rb
@@ -11,6 +11,8 @@ class SetUpTestTables < ActiveRecord::Migration::Current
       t.integer :status, default: 0
 
       if connection.adapter_name == "PostgreSQL"
+        t.text :text_array, array: true
+        t.integer :integer_array, array: true
         t.enum :enum_array, enum_type: :post_enum_array, array: true
       end
 

--- a/test/models/snapshot_test.rb
+++ b/test/models/snapshot_test.rb
@@ -88,6 +88,26 @@ class SnapshotTest < ActiveSupport::TestCase
     @snapshot.build_snapshot_item(Post.first, child_group_name: :foobar)
   end
 
+  def test_build_snapshot_item_handles_text_array_column
+    skip "requires pg gem" unless defined?(PG)
+
+    @snapshot = @snapshot_klass.first
+
+    snapshot_item = @snapshot.build_snapshot_item(Post.first)
+
+    assert_equal ["foo", "bar"], snapshot_item.object["text_array"]
+  end
+
+  def test_build_snapshot_item_handles_integer_array_column
+    skip "requires pg gem" unless defined?(PG)
+
+    @snapshot = @snapshot_klass.first
+
+    snapshot_item = @snapshot.build_snapshot_item(Post.first)
+
+    assert_equal [1, 2], snapshot_item.object["integer_array"]
+  end
+
   def test_build_snapshot_item_handles_enum_array_column
     skip "requires pg gem" unless defined?(PG)
 

--- a/test/models/snapshot_test.rb
+++ b/test/models/snapshot_test.rb
@@ -88,6 +88,16 @@ class SnapshotTest < ActiveSupport::TestCase
     @snapshot.build_snapshot_item(Post.first, child_group_name: :foobar)
   end
 
+  def test_build_snapshot_item_handles_enum_array_column
+    skip "requires pg gem" unless defined?(PG)
+
+    @snapshot = @snapshot_klass.first
+
+    snapshot_item = @snapshot.build_snapshot_item(Post.first)
+
+    assert_equal ["foo", "bar"], snapshot_item.object["enum_array"]
+  end
+
   def test_snapshot_item_stores_enum_column_database_value
     assert Post.defined_enums.has_key?("status")
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -54,7 +54,13 @@ ActiveRecord::MigrationContext.new(File.expand_path("dummy_app/db/migrate/", __d
 require "rspec/mocks/minitest_integration"
 
 post = if defined?(PG)
-  Post.create!(a: 1, b: 3, enum_array: ["foo", "bar"])
+  Post.create!(
+    a: 1,
+    b: 3,
+    text_array: ["foo", "bar"],
+    integer_array: [1, 2],
+    enum_array: ["foo", "bar"]
+  )
 else
   Post.create!(a: 1, b: 3)
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -53,7 +53,11 @@ ActiveRecord::MigrationContext.new(File.expand_path("dummy_app/db/migrate/", __d
 
 require "rspec/mocks/minitest_integration"
 
-post = Post.create!(a: 1, b: 3)
+post = if defined?(PG)
+  Post.create!(a: 1, b: 3, enum_array: ["foo", "bar"])
+else
+  Post.create!(a: 1, b: 3)
+end
 post.create_snapshot!(identifier: 'v1')
 post.update_columns(a: 2, b: 4)
 post.create_snapshot!(identifier: 'v2')


### PR DESCRIPTION
I ran into a bug with a PG enum array column: for those, `attributes_for_database` return a struct:

```ruby
 "target_sizes" => #<struct ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Array::Data encoder=#<PG::TextEncoder::Array:0x000000012ca44e08 "enum[]"  elements_type=nil needs quotation>, values=["XS","S"]>
 ```
 
 which got serialized by `build_snapshot_item` as:
 
 ```ruby
 [["name => enum[]", " elements_type => nil"], " values => [XS", " S]"]
 ```
 
 It should just serialize the values as a standard array: `["XS","S"]`
 
The PR includes a test to catch that bug, and I tried to keep the fix as minimal as possible, hope this looks good but if not feel free to suggest changes !