### PR TITLE
Add tests for all columns types for each DB type

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,6 @@ jobs:
           - ruby: "4.0"
           ### TEST RAILS VERSIONS
           - ruby: "4.0"
-            rails_version: "~> 7.0.0"
-            db_gem_version: "~> 1.4" # fixes sqlite3 gem dependency issue
-          - ruby: "4.0"
             rails_version: "~> 7.1.0"
           - ruby: "4.0"
             rails_version: "~> 7.2.0"

--- a/test/dummy_app/app/models/model_with_all_mysql_column_types.rb
+++ b/test/dummy_app/app/models/model_with_all_mysql_column_types.rb
@@ -1,0 +1,5 @@
+class ModelWithAllMysqlColumnTypes < ActiveRecord::Base
+  include ActiveSnapshot
+
+  self.table_name = "model_with_all_mysql_column_types"
+end

--- a/test/dummy_app/app/models/model_with_all_postgres_column_types.rb
+++ b/test/dummy_app/app/models/model_with_all_postgres_column_types.rb
@@ -1,0 +1,5 @@
+class ModelWithAllPostgresColumnTypes < ActiveRecord::Base
+  include ActiveSnapshot
+
+  self.table_name = "model_with_all_postgres_column_types"
+end

--- a/test/dummy_app/app/models/model_with_all_sqlite_column_types.rb
+++ b/test/dummy_app/app/models/model_with_all_sqlite_column_types.rb
@@ -1,0 +1,5 @@
+class ModelWithAllSqliteColumnTypes < ActiveRecord::Base
+  include ActiveSnapshot
+
+  self.table_name = "model_with_all_sqlite_column_types"
+end

--- a/test/dummy_app/app/models/model_with_serialized_columns.rb
+++ b/test/dummy_app/app/models/model_with_serialized_columns.rb
@@ -1,0 +1,8 @@
+class ModelWithSerializedColumns < ActiveRecord::Base
+  include ActiveSnapshot
+
+  self.table_name = "model_with_serialized_columns"
+
+  serialize :yaml_field, coder: YAML
+  serialize :json_field, coder: JSON
+end

--- a/test/dummy_app/config/application.rb
+++ b/test/dummy_app/config/application.rb
@@ -24,7 +24,7 @@ module Dummy
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = "UTC"
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
@@ -48,5 +48,7 @@ module Dummy
     config.after_initialize do
       ActiveRecord::Migration.migrate(Rails.root.join("db/migrate/*").to_s)
     end
+
+    config.active_record.yaml_column_permitted_classes = [Time, Date, Symbol]
   end
 end

--- a/test/dummy_app/config/database.yml
+++ b/test/dummy_app/config/database.yml
@@ -1,12 +1,12 @@
 default: &default
 <% if defined?(Mysql2) %>
   adapter: mysql2
-  database: active_sort_order_test
+  database: active_snapshot_test
 
 <% elsif defined?(PG) %>
   adapter: postgresql
-  database: active_sort_order_test
-  
+  database: active_snapshot_test
+
 <% elsif defined?(SQLite3) %>
   adapter: sqlite3
   database: db/test.sqlite3

--- a/test/dummy_app/db/migrate/20210128155312_set_up_test_tables.rb
+++ b/test/dummy_app/db/migrate/20210128155312_set_up_test_tables.rb
@@ -1,54 +1,91 @@
 class SetUpTestTables < ActiveRecord::Migration::Current
-
   def change
-    if connection.adapter_name == "PostgreSQL"
-      create_enum :post_enum_array, ["foo", "bar"]
-    end
-
     create_table :posts do |t|
       t.integer :a, :b
-
       t.integer :status, default: 0
-
-      if connection.adapter_name == "PostgreSQL"
-        t.text :text_array, array: true
-        t.integer :integer_array, array: true
-        t.enum :enum_array, enum_type: :post_enum_array, array: true
-      end
-
       t.timestamps
     end
 
     create_table :comments do |t|
       t.string :content
-
       t.references :post
-
       t.timestamps
     end
 
     create_table :notes do |t|
       t.string :body
-
       t.references :post
-
       t.timestamps
     end
 
     create_table :tasks do |t|
       t.string :title
-
       t.references :assignee
       t.references :requester
-
       t.timestamps
     end
 
     create_table :users do |t|
       t.string :name
-
       t.timestamps
     end
-  end
 
+    create_table :model_with_serialized_columns do |t|
+      t.text :yaml_field
+      t.text :json_field
+    end
+
+    if connection.adapter_name == "PostgreSQL"
+      create_enum :some_enum, ["foo", "bar"]
+
+      create_table :model_with_all_postgres_column_types do |t|
+        t.text :text_field
+        t.integer :integer_field
+        t.date :date_field
+        t.time :time_field
+        t.timestamp :timestamp_field
+        t.boolean :boolean_field
+        t.binary :binary_field
+        t.json :json_field
+        t.jsonb :jsonb_field
+        t.inet :inet_field
+        t.cidr :cidr_field
+        t.macaddr :mac_field
+        t.uuid :uuid_field
+        t.bit :bit_field, limit: 8
+        t.money :money_field
+        t.text :text_array_field, array: true
+        t.integer :integer_array_field, array: true
+        t.enum :enum_array_field, enum_type: :some_enum, array: true
+        t.enum :enum_field, enum_type: :some_enum
+      end
+    end
+
+    if connection.adapter_name == "Mysql2"
+      create_table :model_with_all_mysql_column_types do |t|
+        t.text :text_field
+        t.integer :integer_field
+        t.date :date_field
+        t.time :time_field
+        t.timestamp :timestamp_field
+        t.json :json_field
+        t.boolean :boolean_field
+        t.binary :binary_field
+        t.column :enum_field, "ENUM('foo', 'bar')"
+      end
+    end
+
+    if connection.adapter_name == "SQLite"
+      create_table :model_with_all_sqlite_column_types do |t|
+        t.text :text_field
+        t.integer :integer_field
+        t.date :date_field
+        t.time :time_field
+        t.timestamp :timestamp_field
+        t.boolean :boolean_field
+        t.binary :binary_field
+        t.json :json_field
+      end
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 #$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 ENV["RAILS_ENV"] = "test"
+ENV['TZ'] = "UTC"
 
 require "active_support/all"
 
@@ -28,6 +29,13 @@ Pathname.new(__dir__).join("dummy_app/db").glob("*sqlite*").each(&:delete)
 ### Instantiates Rails
 require File.expand_path("../dummy_app/config/environment.rb",  __FILE__)
 
+require 'active_record/tasks/database_tasks'
+db_config = ActiveRecord::Base.configurations.configs_for(env_name: ENV["RAILS_ENV"]).first
+ActiveRecord::Tasks::DatabaseTasks.drop(db_config.configuration_hash) rescue nil
+ActiveRecord::Tasks::DatabaseTasks.create(db_config.configuration_hash)
+ActiveRecord::MigrationContext.new(File.expand_path("dummy_app/db/migrate/", __dir__)).migrate
+ActiveRecord::Tasks::DatabaseTasks.dump_schema(db_config, :ruby)
+
 require "rails/test_help"
 
 class ActiveSupport::TestCase
@@ -47,12 +55,6 @@ Minitest::Reporters.use!(
 )
 
 require "minitest/autorun"
-
-# Run any available migration
-ActiveRecord::MigrationContext.new(File.expand_path("dummy_app/db/migrate/", __dir__)).migrate
-
-# Ensure schema.rb is updated
-ActiveRecord::Migration.maintain_test_schema!
 
 require "rspec/mocks/minitest_integration"
 

--- a/test/unit/mysql_specific_test.rb
+++ b/test/unit/mysql_specific_test.rb
@@ -1,0 +1,87 @@
+require "test_helper"
+
+class MysqlSpecificTest < ActiveSupport::TestCase
+  if defined?(Mysql2)
+    def setup
+      @instance = ModelWithAllMysqlColumnTypes.new(
+        text_field: "some-text",
+        integer_field: 2,
+        date_field: Date.parse("2026-06-03"),
+        time_field: (Time.parse("2026-07-04 04:05:06") if !ActiveSnapshot.config.storage_method_yaml?),
+        timestamp_field: Time.parse("2026-08-05 01:02:03"),
+        json_field: {string: "bar", number: 2, array: [1,2,3]},
+        #binary_field: "0010010", # binary fields have issues currently
+        boolean_field: true,
+        enum_field: "bar",
+      )
+
+      @instance.save!
+    end
+
+    def teardown
+    end
+
+    def test_restore_snapshot_handles_column_serialization
+      snapshot = @instance.create_snapshot!
+
+      snapshot_item = snapshot.snapshot_items.first!
+
+      snapshot_item.restore_item!
+
+      assert_equal(
+        {
+          text_field: "some-text",
+          integer_field: 2,
+          date_field: Date.parse("2026-06-03"),
+          json_field: {"string" => "bar", "number" => 2, "array" => [1,2,3]},
+          binary_field: nil,
+          boolean_field: true,
+          enum_field: "bar",
+        },
+        snapshot_item.item.attributes.symbolize_keys.except(:id, :time_field, :timestamp_field)
+      )
+
+      assert_time_match(Time.parse("2026-08-05 01:02:03"), snapshot_item.item.timestamp_field)
+
+      if !ActiveSnapshot.config.storage_method_yaml?
+        assert_time_match(Time.parse("2000-01-01 04:05:06"), snapshot_item.item.time_field)
+      end
+    end
+
+    def test_diff_handles_column_serialization
+      snapshot = @instance.create_snapshot!
+
+      @instance.assign_attributes(
+        text_field: "other-text",
+        integer_field: 3,
+        date_field: Date.parse("2026-01-03"),
+        time_field: (Time.parse("2026-07-04 07:08:09") if !ActiveSnapshot.config.storage_method_yaml?),
+        timestamp_field: Time.parse("2026-03-05 04:05:06"),
+        json_field: {string: "foo", number: 1, array: [4,5,6]},
+        #binary_field: "0101010101",
+        boolean_field: false,
+        enum_field: "foo",
+      )
+
+      @instance.save!
+
+      diff = ActiveSnapshot::Snapshot.diff(snapshot, @instance)
+
+      assert_equal(["some-text","other-text"], diff.first[:changes][:text_field])
+      assert_equal([2,3], diff.first[:changes][:integer_field])
+      assert_equal([Date.parse("2026-06-03"), Date.parse("2026-01-03")], diff.first[:changes][:date_field])
+      assert_equal([{"string" => "bar", "number" => 2, "array" => [1, 2, 3]}, {"string" => "foo", "number" => 1, "array" => [4, 5, 6]}], diff.first[:changes][:json_field])
+      assert_equal(nil, diff.first[:changes][:binary_field])
+      assert_equal([true, false], diff.first[:changes][:boolean_field])
+      assert_equal(["bar", "foo"], diff.first[:changes][:enum_field])
+
+      assert_time_match(Time.parse("2026-08-05 01:02:03"), diff.first[:changes][:timestamp_field].first)
+      assert_time_match(Time.parse("2026-03-05 04:05:06"), diff.first[:changes][:timestamp_field].last)
+
+      if !ActiveSnapshot.config.storage_method_yaml?
+        assert_time_match(Time.parse("2000-01-01 04:05:06"), diff.first[:changes][:time_field].first)
+        assert_time_match(Time.parse("2000-01-01 07:08:09"), diff.first[:changes][:time_field].last)
+      end
+    end
+  end
+end

--- a/test/unit/postgres_specific_test.rb
+++ b/test/unit/postgres_specific_test.rb
@@ -1,0 +1,128 @@
+require "test_helper"
+
+class PostgresSpecificTest < ActiveSupport::TestCase
+  if defined?(PG)
+    def setup
+      @instance = ModelWithAllPostgresColumnTypes.new(
+        text_field: "some-text",
+        integer_field: 2,
+        date_field: Date.parse("2026-06-03"),
+        time_field: (Time.parse("2026-07-04 04:05:06") if !ActiveSnapshot.config.storage_method_yaml?),
+        timestamp_field: Time.parse("2026-08-05 01:02:03"),
+        #binary_field: "0010010", # binary fields have issues currently
+        boolean_field: true,
+        json_field: {string: "bar", number: 2, array: [1,2,3]},
+        jsonb_field: {string: "baz", number: 3, array: [2,3,4]},
+        inet_field: "192.168.1.55",
+        cidr_field: "192.168.10.0/24",
+        mac_field: "08:00:2b:01:02:03",
+        uuid_field: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+        #bit_field: "00001111", #bit fields have issues currently
+        money_field: BigDecimal("49.99"),
+        text_array_field: ["a","b","c"],
+        integer_array_field: [1,2,3],
+        enum_array_field: ["foo","bar"],
+        enum_field: "bar",
+      )
+
+      @instance.save!
+    end
+
+    def teardown
+    end
+
+    def test_restore_snapshot_handles_column_serialization
+      snapshot = @instance.create_snapshot!
+
+      snapshot_item = snapshot.snapshot_items.first!
+
+      snapshot_item.restore_item!
+
+      assert_equal(
+        {
+          text_field: "some-text",
+          integer_field: 2,
+          date_field: Date.parse("2026-06-03"),
+          boolean_field: true,
+          binary_field: nil,
+          json_field: {"string" => "bar", "number" => 2, "array" => [1,2,3]},
+          jsonb_field: {"string" => "baz", "number" => 3, "array" => [2,3,4]},
+          inet_field: IPAddr.new("192.168.1.55"),
+          cidr_field: IPAddr.new("192.168.10.0/24"),
+          mac_field: "08:00:2b:01:02:03",
+          uuid_field: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+          bit_field: nil,
+          money_field: BigDecimal("49.99"),
+          text_array_field: ["a","b","c"],
+          integer_array_field: [1,2,3],
+          enum_array_field: ["foo","bar"],
+          enum_field: "bar",
+        },
+        snapshot_item.item.attributes.symbolize_keys.except(:id, :time_field, :timestamp_field)
+      )
+
+      assert_time_match(Time.parse("2026-08-05 01:02:03"), snapshot_item.item.timestamp_field)
+
+      if !ActiveSnapshot.config.storage_method_yaml?
+        assert_time_match(Time.parse("2000-01-01 04:05:06"), snapshot_item.item.time_field)
+      end
+    end
+
+    def test_diff_handles_column_serialization
+      snapshot = @instance.create_snapshot!
+
+      @instance.assign_attributes(
+        text_field: "other-text",
+        integer_field: 3,
+        date_field: Date.parse("2026-01-03"),
+        time_field: (Time.parse("2026-07-04 07:08:09") if !ActiveSnapshot.config.storage_method_yaml?),
+        timestamp_field: Time.parse("2026-03-05 04:05:06"),
+        json_field: {string: "foo", number: 1, array: [4,5,6]},
+        #binary_field: "0101010101",
+        boolean_field: false,
+        jsonb_field: {string: "baz2", number: 4, array: [5,2,3,4]},
+        inet_field: "192.168.1.52",
+        cidr_field: "192.168.9.0/24",
+        mac_field: "08:00:2b:01:02:04",
+        uuid_field: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12",
+        #bit_field: "00011111",
+        money_field: BigDecimal("39.99"),
+        text_array_field: ["a","b","d"],
+        integer_array_field: [1,2,4],
+        enum_array_field: ["bar"],
+        enum_field: "foo",
+      )
+
+      @instance.save!
+
+      diff = ActiveSnapshot::Snapshot.diff(snapshot, @instance)
+
+      assert_equal(["some-text","other-text"], diff.first[:changes][:text_field])
+      assert_equal([2,3], diff.first[:changes][:integer_field])
+      assert_equal([Date.parse("2026-06-03"), Date.parse("2026-01-03")], diff.first[:changes][:date_field])
+      assert_equal([{"string" => "bar", "number" => 2, "array" => [1, 2, 3]}, {"string" => "foo", "number" => 1, "array" => [4, 5, 6]}], diff.first[:changes][:json_field])
+      #assert_equal([nil, {"value" => "0101010101"}], diff.first[:changes][:binary_field])
+      assert_equal([true, false], diff.first[:changes][:boolean_field])
+      assert_equal(["bar", "foo"], diff.first[:changes][:enum_field])
+      assert_equal([{"string"=>"baz", "number"=>3, "array"=>[2, 3, 4]}, {"string"=>"baz2", "number"=>4, "array"=>[5, 2, 3, 4]}], diff.first[:changes][:jsonb_field])
+      assert_equal([IPAddr.new("192.168.1.55"), IPAddr.new("192.168.1.52")], diff.first[:changes][:inet_field])
+      assert_equal([IPAddr.new("192.168.10.0/24"), IPAddr.new("192.168.9.0/24")], diff.first[:changes][:cidr_field])
+      assert_equal(["08:00:2b:01:02:03", "08:00:2b:01:02:04"], diff.first[:changes][:mac_field])
+      assert_equal(["a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12"], diff.first[:changes][:uuid_field])
+      #assert_equal(["", ""], diff.first[:changes][:bit_field])
+      assert_equal([BigDecimal("49.99"), BigDecimal("39.99")], diff.first[:changes][:money_field])
+      assert_equal([["a", "b", "c"], ["a", "b", "d"]], diff.first[:changes][:text_array_field])
+      assert_equal([[1, 2, 3], [1, 2, 4]], diff.first[:changes][:integer_array_field])
+      assert_equal([["foo", "bar"], ["bar"]], diff.first[:changes][:enum_array_field])
+      assert_equal(["bar", "foo"], diff.first[:changes][:enum_field])
+
+      assert_time_match(Time.parse("2026-08-05 01:02:03"), diff.first[:changes][:timestamp_field].first)
+      assert_time_match(Time.parse("2026-03-05 04:05:06"), diff.first[:changes][:timestamp_field].last)
+
+      if !ActiveSnapshot.config.storage_method_yaml?
+        assert_time_match(Time.parse("2000-01-01 04:05:06"), diff.first[:changes][:time_field].first)
+        assert_time_match(Time.parse("2000-01-01 07:08:09"), diff.first[:changes][:time_field].last)
+      end
+    end
+  end
+end

--- a/test/unit/serialized_columns_test.rb
+++ b/test/unit/serialized_columns_test.rb
@@ -1,0 +1,75 @@
+require "test_helper"
+
+class SerializedColumnsTest < ActiveSupport::TestCase
+  def setup
+    @instance = ModelWithSerializedColumns.new(
+      yaml_field: {number: 2, foo: "some-foo", bar: "some-bar", nested: {bar: "some-bar", baz: "some-nested-baz"}, timestamp: Time.parse("2026-02-03")},
+      json_field: {json: true, number: 2, foo: "some-foo", bar: "some-bar", nested: {bar: "some-bar", baz: "some-nested-baz"}, timestamp: Time.parse("2026-02-03")},
+    )
+
+    @instance.save!
+  end
+
+  def teardown
+  end
+
+  def test_restore_snapshot_handles_column_serialization
+    snapshot = @instance.create_snapshot!
+
+    snapshot_item = snapshot.snapshot_items.first!
+
+    snapshot_item.restore_item!
+
+    assert_equal(
+      {number: 2, foo: "some-foo", bar: "some-bar", nested: {bar: "some-bar", baz: "some-nested-baz"}, timestamp: Time.parse("2026-02-03")},
+      snapshot_item.item.yaml_field
+    )
+
+    assert_equal(
+      {"json" => true, "number" => 2, "foo" => "some-foo", "bar" => "some-bar", "nested" => {"bar" => "some-bar", "baz" => "some-nested-baz"}, "timestamp" => "2026-02-03T00:00:00.000+00:00"}.stringify_keys,
+      snapshot_item.item.json_field
+    )
+  end
+
+  def test_diff_handles_column_serialization
+    snapshot = @instance.create_snapshot!
+
+    @instance.yaml_field = {foo: "bar"}
+    @instance.json_field = {bar: "baz"}
+
+    diff = ActiveSnapshot::Snapshot.diff(snapshot, @instance)
+
+    assert_equal(
+      {
+        yaml_field: [
+          {
+            number: 2,
+            foo: "some-foo",
+            bar: "some-bar",
+            nested: {
+              bar: "some-bar",
+              baz: "some-nested-baz"
+            },
+            timestamp: Time.parse("2026-02-03")
+          },
+          {foo: "bar"}
+        ],
+        json_field: [
+          {
+            "json" => true,
+            "number" => 2,
+            "foo" => "some-foo",
+            "bar" => "some-bar",
+            "nested" => {
+              "bar" => "some-bar",
+              "baz" => "some-nested-baz"
+            },
+            "timestamp" => "2026-02-03T00:00:00.000+00:00"
+          },
+          {"bar" => "baz"}
+        ]
+      },
+      diff.first[:changes]
+    )
+  end
+end

--- a/test/unit/snapshot_test.rb
+++ b/test/unit/snapshot_test.rb
@@ -89,57 +89,6 @@ class SnapshotTest < ActiveSupport::TestCase
     snapshot.build_snapshot_item(Post.create!(a: 1, b: 3), child_group_name: :foobar)
   end
 
-  def test_build_snapshot_item_handles_text_array_column
-    skip "requires pg gem" unless defined?(PG)
-
-    post = Post.create!(
-      a: 1,
-      b: 3,
-      text_array: ["foo", "bar"],
-      integer_array: [1, 2],
-      enum_array: ["foo", "bar"]
-    )
-    snapshot = post.create_snapshot!(identifier: "v1")
-
-    snapshot_item = snapshot.build_snapshot_item(Post.create!(a: 1, b: 3))
-
-    assert_equal ["foo", "bar"], snapshot_item.object["text_array"]
-  end
-
-  def test_build_snapshot_item_handles_integer_array_column
-    skip "requires pg gem" unless defined?(PG)
-
-    post = Post.create!(
-      a: 1,
-      b: 3,
-      text_array: ["foo", "bar"],
-      integer_array: [1, 2],
-      enum_array: ["foo", "bar"]
-    )
-    snapshot = post.create_snapshot!(identifier: "v1")
-
-    snapshot_item = snapshot.build_snapshot_item(Post.create!(a: 1, b: 3))
-
-    assert_equal [1, 2], snapshot_item.object["integer_array"]
-  end
-
-  def test_build_snapshot_item_handles_enum_array_column
-    skip "requires pg gem" unless defined?(PG)
-
-    post = Post.create!(
-      a: 1,
-      b: 3,
-      text_array: ["foo", "bar"],
-      integer_array: [1, 2],
-      enum_array: ["foo", "bar"]
-    )
-    snapshot = post.create_snapshot!(identifier: "v1")
-
-    snapshot_item = snapshot.build_snapshot_item(Post.create!(a: 1, b: 3))
-
-    assert_equal ["foo", "bar"], snapshot_item.object["enum_array"]
-  end
-
   def test_snapshot_item_stores_enum_column_database_value
     assert Post.defined_enums.has_key?("status")
 

--- a/test/unit/sqlite_specific_test.rb
+++ b/test/unit/sqlite_specific_test.rb
@@ -1,0 +1,81 @@
+require "test_helper"
+
+class SqliteSpecificTest < ActiveSupport::TestCase
+  if defined?(SQLite3)
+    def setup
+      @instance = ModelWithAllSqliteColumnTypes.new(
+        text_field: "some-text",
+        integer_field: 2,
+        date_field: Date.parse("2026-06-03"),
+        time_field: (Time.parse("2026-07-04 04:05:06") if !ActiveSnapshot.config.storage_method_yaml?),
+        timestamp_field: Time.parse("2026-08-05 01:02:03"),
+        json_field: {string: "bar", number: 2, array: [1,2,3]},
+        #binary_field: "0010010", # binary fields have issues currently
+        boolean_field: true,
+      )
+
+      @instance.save!
+    end
+
+    def teardown
+    end
+
+    def test_restore_snapshot_handles_column_serialization
+      snapshot = @instance.create_snapshot!
+
+      snapshot_item = snapshot.snapshot_items.first!
+
+      snapshot_item.restore_item!
+
+      assert_equal(
+        {
+          text_field: "some-text",
+          integer_field: 2,
+          date_field: Date.parse("2026-06-03"),
+          json_field: {"string" => "bar", "number" => 2, "array" => [1,2,3]},
+          binary_field: nil,
+          boolean_field: true,
+        },
+        snapshot_item.item.attributes.symbolize_keys.except(:id, :time_field, :timestamp_field)
+      )
+
+      assert_time_match(Time.parse("2026-08-05 01:02:03"), snapshot_item.item.timestamp_field)
+
+      if !ActiveSnapshot.config.storage_method_yaml?
+        assert_time_match(Time.parse("2000-01-01 04:05:06"), snapshot_item.item.time_field)
+      end
+    end
+
+    def test_diff_handles_column_serialization
+      snapshot = @instance.create_snapshot!
+
+      @instance.assign_attributes(
+        text_field: "other-text",
+        integer_field: 3,
+        date_field: Date.parse("2026-01-03"),
+        time_field: (Time.parse("2026-07-04 07:08:09") if !ActiveSnapshot.config.storage_method_yaml?),
+        timestamp_field: Time.parse("2026-03-05 04:05:06"),
+        json_field: {string: "foo", number: 1, array: [4,5,6]},
+        #binary_field: "0101010101",
+        boolean_field: false,
+      )
+
+      diff = ActiveSnapshot::Snapshot.diff(snapshot, @instance)
+
+      assert_equal(["some-text","other-text"], diff.first[:changes][:text_field])
+      assert_equal([2,3], diff.first[:changes][:integer_field])
+      assert_equal([Date.parse("2026-06-03"), Date.parse("2026-01-03")], diff.first[:changes][:date_field])
+      assert_equal([{"string" => "bar", "number" => 2, "array" => [1, 2, 3]}, {"string" => "foo", "number" => 1, "array" => [4, 5, 6]}], diff.first[:changes][:json_field])
+      #assert_equal([nil, {"value" => "0101010101"}], diff.first[:changes][:binary_field])
+      assert_equal([true, false], diff.first[:changes][:boolean_field])
+
+      assert_time_match(Time.parse("2026-08-05 01:02:03"), diff.first[:changes][:timestamp_field].first)
+      assert_time_match(Time.parse("2026-03-05 04:05:06"), diff.first[:changes][:timestamp_field].last)
+
+      if !ActiveSnapshot.config.storage_method_yaml?
+        assert_time_match(Time.parse("2000-01-01 04:05:06"), diff.first[:changes][:time_field].first)
+        assert_time_match(Time.parse("2000-01-01 07:08:09"), diff.first[:changes][:time_field].last)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Ensure all possible columns types for each database are properly serialized in snapshots
- Drop Rails 7.0 from the test suite because it doesnt properly handle `serialize :column_name, coder: JSON` even though it still works for all other things. Its getting pretty old so its simpler to just drop it from the test suite, im sure if anyone is still on Rails 7.0 its going to be super easy to upgrade to 7.1